### PR TITLE
v5.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-json-schema-export",
-  "version": "5.2.0-beta.2",
+  "version": "5.2.0",
   "description": "Exports SHR data elements from SHR models to JSON Schema",
   "author": "",
   "license": "Apache-2.0",
@@ -16,17 +16,16 @@
     "lint": "./node_modules/.bin/eslint .",
     "lint:fix": "./node_modules/.bin/eslint . --fix"
   },
-  "dependencies": {
-  },
+  "dependencies": {},
   "devDependencies": {
+    "ajv": "^5.2.0",
     "bunyan": "^1.8.9",
     "chai": "^3.5.0",
     "eslint": "^3.6.1",
     "mocha": "^3.2.0",
     "shr-expand": "^5.2.6",
     "shr-models": "^5.2.2",
-    "shr-test-helpers": "https://github.com/standardhealth/shr-test-helpers#type-constrained-reference-test",
-    "ajv": "^5.2.0"
+    "shr-test-helpers": "^5.1.2"
   },
   "peerDependencies": {
     "bunyan": "^1.8.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -909,9 +909,9 @@ shr-models@^5.2.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-5.2.2.tgz#42b9f13deded480628529e22bca09af546f8ba81"
 
-"shr-test-helpers@https://github.com/standardhealth/shr-test-helpers#type-constrained-reference-test":
-  version "5.1.1"
-  resolved "https://github.com/standardhealth/shr-test-helpers#017a928974110b1a0e93e364285f79fbe460bfd1"
+shr-test-helpers@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/shr-test-helpers/-/shr-test-helpers-5.1.2.tgz#79e40bfde12507bb5e9f84daae84b6d9b271f56c"
 
 slice-ansi@0.0.4:
   version "0.0.4"


### PR DESCRIPTION
Bumps version number and sets shr-test-helper dependency to released version.