### PR TITLE
Ignore constraints on IncludesType fields

### DIFF
--- a/lib/export.js
+++ b/lib/export.js
@@ -888,10 +888,10 @@ function extractConstraintPath(constraint, valueDef, dataElementSpecs) {
           target = currentDef.fields.find((field) => pathId.equals(field.identifier));
           if (!target) {
             // It's possible that the field is actually defined as an "includes type" constraint on a list.
-            // In this case, do nothing, because right now there isn't a valid way to represent includesType
-            // constraints in the schema.
+            // In this case, do nothing, because right now there isn't a valid way to represent further constraints
+            // on includesType elements in the schema.
             if (valueDef.constraintsFilter.includesType.constraints.some(c => c.isA.equals(pathId))) {
-              // TODO: Eventually, somehow, support includesType constraints
+              logger.warn('Cannot enforce constraint %s on Element %s since %s refers to an type introduced by an "includesType" constraint', JSON.stringify(constraint, null, 2), JSON.stringify(currentDef, null, 2), pathId);
             } else {
               logger.error('Element %s lacked a field or a value that matched %s as part of constraint %s', JSON.stringify(currentDef, null, 2), pathId, JSON.stringify(constraint, null, 2));
             }

--- a/lib/export.js
+++ b/lib/export.js
@@ -887,7 +887,14 @@ function extractConstraintPath(constraint, valueDef, dataElementSpecs) {
         } else {
           target = currentDef.fields.find((field) => pathId.equals(field.identifier));
           if (!target) {
-            logger.error('Element %s lacked a field or a value that matched %s as part of constraint %s', JSON.stringify(currentDef, null, 2), pathId, JSON.stringify(constraint, null, 2));
+            // It's possible that the field is actually defined as an "includes type" constraint on a list.
+            // In this case, do nothing, because right now there isn't a valid way to represent includesType
+            // constraints in the schema.
+            if (valueDef.constraintsFilter.includesType.constraints.some(c => c.isA.equals(pathId))) {
+              // TODO: Eventually, somehow, support includesType constraints
+            } else {
+              logger.error('Element %s lacked a field or a value that matched %s as part of constraint %s', JSON.stringify(currentDef, null, 2), pathId, JSON.stringify(constraint, null, 2));
+            }
             return {};
           }
           normalizedPath.push(pathId.fqn);
@@ -938,7 +945,14 @@ function extractUnnormalizedConstraintPath(constraint, valueDef, dataElementSpec
       } else {
         const found = currentDef.fields.some((field) => pathId.equals(field.identifier));
         if (!found) {
-          logger.error('Element %s lacked a field or a value that matched %s as part of constraint %s', JSON.stringify(currentDef, null, 2), pathId, JSON.stringify(constraint, null, 2));
+          // It's possible that the field is actually defined as an "includes type" constraint on a list.
+          // In this case, do nothing, because right now there isn't a valid way to represent includesType
+          // constraints in the schema.
+          if (valueDef.constraintsFilter.includesType.constraints.some(c => c.isA.equals(pathId))) {
+            // TODO: Eventually, somehow, support includesType constraints
+          } else {
+            logger.error('Element %s lacked a field or a value that matched %s as part of constraint %s', JSON.stringify(currentDef, null, 2), pathId, JSON.stringify(constraint, null, 2));
+          }
           return {};
         }
         normalizedPath.push(pathId.fqn);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-json-schema-export",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "description": "Exports SHR data elements from SHR models to JSON Schema",
   "author": "",
   "license": "Apache-2.0",


### PR DESCRIPTION
**NOTE: All PR's into Flux-based branches require sign-off from multiple teams. Please do not merge until sign-off is confirmed.**

Since the JSON schema doesn't yet represent includesType constraints, we need to ignore any additional constraints that are on the "included" field types.