### PR TITLE
Logical models

### DIFF
--- a/lib/export.js
+++ b/lib/export.js
@@ -830,6 +830,12 @@ function makePrimitiveObject(id, target = {}) {
 function extractConstraintPath(constraint, valueDef, dataElementSpecs) {
   if (constraint.onValue) {
     return extractUnnormalizedConstraintPath(constraint, valueDef, dataElementSpecs);
+  } else if (constraint.path.length > 0 && constraint.path[constraint.path.length-1].isValueKeyWord) {
+    // Essentially the same as above, when onValue is never checked again, so just chop it off
+    // treat it like above.  TODO: Determine if this is really the right approach.
+    const simpleConstraint = constraint.clone();
+    simpleConstraint.path = simpleConstraint.path.slice(0, simpleConstraint.path.length-1);
+    return extractUnnormalizedConstraintPath(simpleConstraint, valueDef, dataElementSpecs);
   }
 
   if (!constraint.hasPath()) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-json-schema-export",
-  "version": "5.2.1",
+  "version": "5.2.2",
   "description": "Exports SHR data elements from SHR models to JSON Schema",
   "author": "",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "chai": "^3.5.0",
     "eslint": "^3.6.1",
     "mocha": "^3.2.0",
-    "shr-expand": "^5.2.6",
-    "shr-models": "^5.2.2",
+    "shr-expand": "^5.5.0",
+    "shr-models": "^5.5.0",
     "shr-test-helpers": "^5.1.2"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -901,13 +901,13 @@ shelljs@^0.7.5:
     interpret "^1.0.0"
     rechoir "^0.6.2"
 
-shr-expand@^5.2.6:
-  version "5.2.6"
-  resolved "https://registry.yarnpkg.com/shr-expand/-/shr-expand-5.2.6.tgz#47b82c0eb31c974e9fcfcdfc6938952804ac3bdb"
+shr-expand@^5.5.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/shr-expand/-/shr-expand-5.5.0.tgz#add3fd793d97350bdb9ae8f1ff195ab41226a9e2"
 
-shr-models@^5.2.2:
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-5.2.2.tgz#42b9f13deded480628529e22bca09af546f8ba81"
+shr-models@^5.5.0:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-5.5.0.tgz#41c163bfb22aa39678c2bafebccccb50a8574a3a"
 
 shr-test-helpers@^5.1.2:
   version "5.1.2"


### PR DESCRIPTION
This PR fixes a bug that surfaced when operating against the US Breast Cancer specification.

This code represents the exact code used to generate the HL7 US Breast Cancer May 2018 ballot.  Note that it should be tested against standardhealth/shr_spec#may-2018-ballot-topic-context.  There are known issues testing against standardhealth/shr_spec#master, but we need to cut a release that matches exactly the toolchain used for the ballot.

This is one of seven PRs related to the logical models and HL7 ballot:
- shr-models
- shr-text-import
- shr-expand
- shr-fhir-export
- shr-json-schema-export
- shr-test-helpers
- shr-cli