### PR TITLE
Eliminate namespaces from properties from JSON Schema

### DIFF
--- a/lib/export.js
+++ b/lib/export.js
@@ -131,9 +131,29 @@ function namespaceToSchema(ns, dataElementsSpecs, baseSchemaURL, baseTypeURL) {
         }
       }
       if (def.fields.length) {
+        const fieldNameMap = {};
+        const clashingNames = {};
         for (const field of def.fields) {
-          if (!(field instanceof TBD) && !isValidField(field) || (field.inheritance === INHERITED)) {
-            continue;
+          if (!(field instanceof TBD)) {
+            if (!isValidField(field)) {
+              continue;
+            } else if (field.inheritance === INHERITED) {
+              if (fieldNameMap[field.identifier.name]) {
+                logger.error(`ERROR: clashing property names: %s and %s ERROR_CODE: 12038`, fieldNameMap[field.identifier.name].fqn, field.identifier.fqn);
+                clashingNames[field.identifier.name] = true;
+              } else {
+                fieldNameMap[field.identifier.name] = field.identifier;
+              }
+              continue;
+            }
+
+            if (fieldNameMap[field.identifier.name]) {
+              logger.error(`ERROR: clashing property names: %s and %s ERROR_CODE: 12038`, fieldNameMap[field.identifier.name].fqn, field.identifier.fqn);
+              clashingNames[field.identifier.name] = true;
+              continue;
+            } else {
+              fieldNameMap[field.identifier.name] = field.identifier;
+            }
           }
           const card = field.effectiveCard;
           if (card && card.isZeroedOut) {
@@ -149,11 +169,16 @@ function namespaceToSchema(ns, dataElementsSpecs, baseSchemaURL, baseTypeURL) {
             needsEntryType = false;
           }
 
-          schemaDef.properties[field.identifier.fqn] = value;
+          schemaDef.properties[field.identifier.name] = value;
           if (required) {
-            requiredProperties.push(field.identifier.fqn);
+            requiredProperties.push(field.identifier.name);
           }
         }
+
+        for (const clashingName in clashingNames) {
+          delete schemaDef.properties[clashingName];
+        }
+        requiredProperties = requiredProperties.filter(propName => !(propName in clashingNames));
       } else if (!def.value) {
         schemaDef.type = 'object';
         schemaDef.description = 'Empty DataElement?';
@@ -177,9 +202,9 @@ function namespaceToSchema(ns, dataElementsSpecs, baseSchemaURL, baseTypeURL) {
         wholeDef.description = descriptionList.join('\n');
       }
       if (needsEntryType) {
-        schemaDef.properties['shr.base.EntryType'] = nonEntryEntryTypeField;
+        schemaDef.properties['EntryType'] = nonEntryEntryTypeField;
         if (def.identifier.fqn !== 'shr.base.EntryType') {
-          requiredProperties.push('shr.base.EntryType');
+          requiredProperties.push('EntryType');
         }
       }
 
@@ -265,10 +290,10 @@ function flatNamespaceToSchema(ns, dataElementsSpecs, baseSchemaURL, baseTypeURL
           continue;
         }
 
-        const qualifiedName = field.identifier.fqn;
-        schemaDef.properties[qualifiedName] = value;
-        if (required && (requiredProperties.indexOf(qualifiedName) === -1)) {
-          requiredProperties.push(qualifiedName);
+        const fieldName = field.identifier.name;
+        schemaDef.properties[fieldName] = value;
+        if (required && (requiredProperties.indexOf(fieldName) === -1)) {
+          requiredProperties.push(fieldName);
         }
       }
       if (def.isEntry) {
@@ -903,7 +928,7 @@ function extractConstraintPath(constraint, valueDef, dataElementSpecs) {
             }
             return {};
           }
-          normalizedPath.push(pathId.fqn);
+          normalizedPath.push(pathId.name);
         }
       }
       currentDef = newDef;
@@ -961,7 +986,7 @@ function extractUnnormalizedConstraintPath(constraint, valueDef, dataElementSpec
           }
           return {};
         }
-        normalizedPath.push(pathId.fqn);
+        normalizedPath.push(pathId.name);
       }
     }
     currentDef = newDef;

--- a/lib/export.js
+++ b/lib/export.js
@@ -778,11 +778,11 @@ function makeRef(id, enclosingNamespace, baseSchemaURL) {
 function makeShrRefObject(refs, baseTypeURL, target = {}) {
   target.type = 'object';
   target.properties = {
-    ShrId: { type: 'string' },
-    EntryId: { type: 'string' },
-    EntryType: { type: 'string' }
+    _ShrId: { type: 'string' },
+    _EntryId: { type: 'string' },
+    _EntryType: { type: 'string' }
   };
-  target.required = ['ShrId', 'EntryType', 'EntryId'];
+  target.required = ['_ShrId', '_EntryType', '_EntryId'];
   target.refType = refs.map((ref) => `${baseTypeURL}${namespaceToURLPathSegment(ref.identifier.namespace)}/${ref.identifier.name}`);
   return target;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-json-schema-export",
-  "version": "5.2.3",
+  "version": "5.3.0",
   "description": "Exports SHR data elements from SHR models to JSON Schema",
   "author": "",
   "license": "Apache-2.0",

--- a/test/export_test.js
+++ b/test/export_test.js
@@ -109,13 +109,13 @@ const stubSchema = JSON.parse(`{
         {
           "type": "object",
           "properties": {
-            "shr.base.ShrId": {
+            "ShrId": {
               "$ref": "#/definitions/RequiredString"
             },
-            "shr.base.EntryId": {
+            "EntryId": {
               "$ref": "#/definitions/RequiredString"
             },
-            "shr.core.CreationTime": {
+            "CreationTime": {
               "type": "object",
               "properties": {
                 "Value": {
@@ -125,15 +125,15 @@ const stubSchema = JSON.parse(`{
               },
               "required": [ "Value" ]
             },
-            "shr.base.LastUpdated": {
+            "LastUpdated": {
               "$ref": "#/definitions/RequiredString"
             }
           },
           "required": [
-            "shr.base.ShrId",
-            "shr.base.EntryId",
-            "shr.core.CreationTime",
-            "shr.base.LastUpdated"
+            "ShrId",
+            "EntryId",
+            "CreationTime",
+            "LastUpdated"
           ]
         }
       ]
@@ -154,16 +154,16 @@ const stubSchema = JSON.parse(`{
       "type": "object",
       "properties": {
         "Value": { "type": "string", "format": "uri" },
-        "shr.base.EntryType": { "$ref": "#/definitions/EntryType" }
+        "EntryType": { "$ref": "#/definitions/EntryType" }
       },
       "required": [ "Value" ]
     },
     "Any": {
       "type": "object",
       "properties": {
-        "shr.base.EntryType": { "$ref": "#/definitions/EntryType" }
+        "EntryType": { "$ref": "#/definitions/EntryType" }
       },
-      "required": [ "shr.base.EntryType" ]
+      "required": [ "EntryType" ]
     }
   }
 }`);

--- a/test/fixtures/AbstractAndPlainGroup.schema.json
+++ b/test/fixtures/AbstractAndPlainGroup.schema.json
@@ -16,10 +16,10 @@
           {
             "type": "object",
             "properties": {
-              "shr.test.Simple": { "$ref": "#/definitions/Simple" },
-              "shr.test.Plain": { "$ref": "#/definitions/Plain" }
+              "Simple": { "$ref": "#/definitions/Simple" },
+              "Plain": { "$ref": "#/definitions/Plain" }
             },
-            "required": ["shr.test.Simple", "shr.test.Plain"]
+            "required": ["Simple", "Plain"]
           }
         ]
       },
@@ -44,12 +44,12 @@
         "concepts": [ { "code": "bar", "codeSystem": "http://foo.org", "displayText": "Foobar"}],
         "type": "object",
         "properties": {
-          "shr.base.EntryType": { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType" },
+          "EntryType": { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType" },
           "Value": {
             "type": "string"
           }
         },
-        "required": ["Value", "shr.base.EntryType"]
+        "required": ["Value", "EntryType"]
       }
     }
   }

--- a/test/fixtures/BooleanAndCodeConstraints.schema.json
+++ b/test/fixtures/BooleanAndCodeConstraints.schema.json
@@ -26,7 +26,7 @@
                   { "enum": [ true ] }
                 ]
               },
-              "shr.test.Bool": {
+              "Bool": {
                 "allOf": [
                   {
                     "properties": {
@@ -36,7 +36,7 @@
                   { "$ref": "#/definitions/Bool" }
                 ]
               },
-              "shr.test.Coded": {
+              "Coded": {
                 "properties": {
                   "Value": {
                     "code": { "code": "bar", "codeSystem": "http://foo.org", "displayText": "Foobar"}
@@ -52,12 +52,12 @@
         "type": "object",
         "description": "A boolean element.",
         "properties": {
-          "shr.base.EntryType": {"$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType" },
+          "EntryType": {"$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType" },
           "Value": {
             "type": "boolean"
           }
         },
-        "required": ["shr.base.EntryType"]
+        "required": ["EntryType"]
       },
       "Group": {
         "description": "It is a group of elements",
@@ -70,9 +70,9 @@
           {
             "type": "object",
             "properties": {
-              "shr.test.Simple": { "$ref": "#/definitions/Simple" },
-              "shr.test.Coded": { "$ref": "#/definitions/Coded" },
-              "shr.test.ElementValue": {
+              "Simple": { "$ref": "#/definitions/Simple" },
+              "Coded": { "$ref": "#/definitions/Coded" },
+              "ElementValue": {
                 "type": "array",
                 "minItems": 0,
                 "items": {
@@ -80,7 +80,7 @@
                 }
               }
             },
-            "required": ["shr.test.Simple"]
+            "required": ["Simple"]
           }
         ]
       },

--- a/test/fixtures/ChoiceValueSetConstraint.schema.json
+++ b/test/fixtures/ChoiceValueSetConstraint.schema.json
@@ -17,7 +17,7 @@
           {
             "type": "object",
             "properties": {
-              "shr.test.CodedChoice": {
+              "CodedChoice": {
                 "allOf": [
                   {
                     "properties": {

--- a/test/fixtures/Group.schema.json
+++ b/test/fixtures/Group.schema.json
@@ -23,9 +23,9 @@
           {
             "type": "object",
             "properties": {
-              "shr.test.Simple": { "$ref": "#/definitions/Simple" },
-              "shr.test.Coded": { "$ref": "#/definitions/Coded" },
-              "shr.test.ElementValue": {
+              "Simple": { "$ref": "#/definitions/Simple" },
+              "Coded": { "$ref": "#/definitions/Coded" },
+              "ElementValue": {
                 "type": "array",
                 "minItems": 0,
                 "items": {
@@ -33,7 +33,7 @@
                 }
               }
             },
-            "required": ["shr.test.Simple"]
+            "required": ["Simple"]
           }
         ]
       },

--- a/test/fixtures/GroupDerivative.schema.json
+++ b/test/fixtures/GroupDerivative.schema.json
@@ -39,9 +39,9 @@
           {
             "type": "object",
             "properties": {
-              "shr.test.Simple": { "$ref": "#/definitions/Simple" },
-              "shr.test.Coded": { "$ref": "#/definitions/Coded" },
-              "shr.test.ElementValue": {
+              "Simple": { "$ref": "#/definitions/Simple" },
+              "Coded": { "$ref": "#/definitions/Coded" },
+              "ElementValue": {
                 "type": "array",
                 "minItems": 0,
                 "items": {
@@ -49,7 +49,7 @@
                 }
               }
             },
-            "required": ["shr.test.Simple"]
+            "required": ["Simple"]
           }
         ]
       },

--- a/test/fixtures/GroupPathClash.schema.json
+++ b/test/fixtures/GroupPathClash.schema.json
@@ -15,13 +15,7 @@
           { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
           {
             "type": "object",
-            "properties": {
-              "shr.test.Simple": { "$ref": "#/definitions/Simple" },
-              "shr.other.test.Simple": {
-                "$ref": "https://standardhealthrecord.org/test/shr/other/test#/definitions/Simple"
-              }
-            },
-            "required": ["shr.test.Simple"]
+            "properties": {}
           }
         ]
       },

--- a/test/fixtures/GroupPathClash_errors.schema.json
+++ b/test/fixtures/GroupPathClash_errors.schema.json
@@ -1,0 +1,7 @@
+[
+  {
+    "shrId": "shr.test.GroupPathClash",
+    "level": 50,
+    "msg": "ERROR: clashing property names: shr.test.Simple and shr.other.test.Simple ERROR_CODE: 12038"
+  }
+]

--- a/test/fixtures/GroupWithChoiceOfChoice.schema.json
+++ b/test/fixtures/GroupWithChoiceOfChoice.schema.json
@@ -35,10 +35,10 @@
                   ]
                 }
               },
-              "shr.test.Simple": { "$ref": "#/definitions/Simple" },
-              "shr.test.Coded": { "$ref": "#/definitions/Coded" }
+              "Simple": { "$ref": "#/definitions/Simple" },
+              "Coded": { "$ref": "#/definitions/Coded" }
             },
-            "required": [ "shr.test.Simple" ]
+            "required": [ "Simple" ]
           }
         ]
       },

--- a/test/fixtures/NestedCardConstraint.schema.json
+++ b/test/fixtures/NestedCardConstraint.schema.json
@@ -15,16 +15,16 @@
           {
             "type": "object",
             "properties": {
-              "shr.test.OptionalField": {
+              "OptionalField": {
                 "allOf": [
                   { "$ref": "#/definitions/OptionalField" },
                   {
-                    "required": ["shr.test.OptionalValue"]
+                    "required": ["OptionalValue"]
                   }
                 ]
               }
             },
-            "required": ["shr.test.OptionalField"]
+            "required": ["OptionalField"]
           }
         ]
       },
@@ -32,23 +32,23 @@
         "description": "An element with an optional field.",
         "type": "object",
         "properties": {
-          "shr.base.EntryType": { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType" },
-          "shr.test.OptionalValue": {
+          "EntryType": { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType" },
+          "OptionalValue": {
             "$ref": "#/definitions/OptionalValue"
           }
         },
-        "required": ["shr.base.EntryType"]
+        "required": ["EntryType"]
       },
       "OptionalValue": {
         "description": "An element with an optional value.",
         "type": "object",
         "properties": {
-          "shr.base.EntryType": { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType" },
+          "EntryType": { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType" },
           "Value": {
             "type": "string"
           }
         },
-        "required": ["shr.base.EntryType"]
+        "required": ["EntryType"]
       }
     }
   }

--- a/test/fixtures/NestedListCardConstraints.schema.json
+++ b/test/fixtures/NestedListCardConstraints.schema.json
@@ -15,11 +15,11 @@
           {
             "type": "object",
             "properties": {
-              "shr.test.ListField": {
+              "ListField": {
                 "allOf": [
                   {
                     "properties": {
-                      "shr.test.OptionalList": {
+                      "OptionalList": {
                         "allOf": [
                           {
                             "properties": {
@@ -39,7 +39,7 @@
                 ]
               }
             },
-            "required": ["shr.test.ListField"]
+            "required": ["ListField"]
           }
         ]
       },
@@ -47,18 +47,18 @@
         "description": "An element with a list field.",
         "type": "object",
         "properties": {
-          "shr.base.EntryType": { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType" },
-          "shr.test.OptionalList": {
+          "EntryType": { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType" },
+          "OptionalList": {
             "$ref": "#/definitions/OptionalList"
           }
         },
-        "required": ["shr.test.OptionalList", "shr.base.EntryType"]
+        "required": ["OptionalList", "EntryType"]
       },
       "OptionalList": {
         "description": "An element with an optional list.",
         "type": "object",
         "properties": {
-          "shr.base.EntryType": { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType" },
+          "EntryType": { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType" },
           "Value": {
             "type": "array",
             "minItems": 0,
@@ -67,7 +67,7 @@
             }
           }
         },
-        "required": ["shr.base.EntryType"]
+        "required": ["EntryType"]
       }
     }
   }

--- a/test/fixtures/NestedValueSetConstraints.schema.json
+++ b/test/fixtures/NestedValueSetConstraints.schema.json
@@ -20,7 +20,7 @@
           {
             "type": "object",
             "properties": {
-              "shr.test.Coded": {
+              "Coded": {
                 "properties": {
                   "Value": {
                     "valueSet": {
@@ -45,9 +45,9 @@
           {
             "type": "object",
             "properties": {
-              "shr.test.Simple": { "$ref": "#/definitions/Simple" },
-              "shr.test.Coded": { "$ref": "#/definitions/Coded" },
-              "shr.test.ElementValue": {
+              "Simple": { "$ref": "#/definitions/Simple" },
+              "Coded": { "$ref": "#/definitions/Coded" },
+              "ElementValue": {
                 "type": "array",
                 "minItems": 0,
                 "items": {
@@ -55,7 +55,7 @@
                 }
               }
             },
-            "required": ["shr.test.Simple"]
+            "required": ["Simple"]
           }
         ]
       },

--- a/test/fixtures/NotDoneDerivative.schema.json
+++ b/test/fixtures/NotDoneDerivative.schema.json
@@ -34,11 +34,11 @@
           {
             "type": "object",
             "properties": {
-              "shr.test.Simple": {
+              "Simple": {
                 "$ref": "#/definitions/Simple"
               }
             },
-            "required": [ "shr.test.Simple" ]
+            "required": [ "Simple" ]
           }
         ]
       },

--- a/test/fixtures/ReferenceChoice.schema.json
+++ b/test/fixtures/ReferenceChoice.schema.json
@@ -18,11 +18,11 @@
               "Value": {
                 "type": "object",
                 "properties": {
-                  "ShrId": { "type": "string" },
-                  "EntryType": { "type": "string" },
-                  "EntryId": { "type": "string" }
+                  "_ShrId": { "type": "string" },
+                  "_EntryType": { "type": "string" },
+                  "_EntryId": { "type": "string" }
                 },
-                "required": ["ShrId", "EntryType", "EntryId"],
+                "required": ["_ShrId", "_EntryType", "_EntryId"],
                 "refType": ["http://standardhealthrecord.org/spec/shr/other/test/Simple", "http://standardhealthrecord.org/spec/shr/test/Coded"]
               }
             },

--- a/test/fixtures/SimpleReference.schema.json
+++ b/test/fixtures/SimpleReference.schema.json
@@ -18,11 +18,11 @@
               "Value": {
                 "type": "object",
                 "properties": {
-                  "ShrId": { "type": "string" },
-                  "EntryType": { "type": "string" },
-                  "EntryId": { "type": "string" }
+                  "_ShrId": { "type": "string" },
+                  "_EntryType": { "type": "string" },
+                  "_EntryId": { "type": "string" }
                 },
-                "required": ["ShrId", "EntryType", "EntryId"],
+                "required": ["_ShrId", "_EntryType", "_EntryId"],
                 "refType": ["http://standardhealthrecord.org/spec/shr/test/Simple"]
               }
             },

--- a/test/fixtures/TypeConstrainedChoices.schema.json
+++ b/test/fixtures/TypeConstrainedChoices.schema.json
@@ -20,7 +20,7 @@
           {
             "type": "object",
             "properties": {
-              "shr.test.Choice": {
+              "Choice": {
                 "allOf": [
                   {
                     "properties": {
@@ -31,7 +31,7 @@
                 ]
               }
             },
-            "required": ["shr.test.Choice"]
+            "required": ["Choice"]
           }
         ]
       },
@@ -42,11 +42,11 @@
           {
             "type": "object",
             "properties": {
-              "shr.test.TwoDeepChoiceField": {
+              "TwoDeepChoiceField": {
                 "allOf": [
                   {
                     "properties": {
-                      "shr.test.ChoiceValue": {
+                      "ChoiceValue": {
                         "properties": {
                           "Value": {
                             "properties": {
@@ -84,7 +84,7 @@
           {
             "type": "object",
             "properties": {
-              "shr.test.ChoiceValue": { "$ref": "#/definitions/ChoiceValue" }
+              "ChoiceValue": { "$ref": "#/definitions/ChoiceValue" }
             }
           }
         ]

--- a/test/fixtures/TypeConstrainedReference.schema.json
+++ b/test/fixtures/TypeConstrainedReference.schema.json
@@ -23,11 +23,11 @@
                   {
                     "type": "object",
                     "properties": {
-                      "ShrId": { "type": "string" },
-                      "EntryType": { "type": "string" },
-                      "EntryId": { "type": "string" }
+                      "_ShrId": { "type": "string" },
+                      "_EntryType": { "type": "string" },
+                      "_EntryId": { "type": "string" }
                     },
-                    "required": ["ShrId", "EntryType", "EntryId"],
+                    "required": ["_ShrId", "_EntryType", "_EntryId"],
                     "refType": ["http://standardhealthrecord.org/spec/shr/test/Simple"]
                   },
                   { "refType": ["http://standardhealthrecord.org/spec/shr/test/SimpleChild"] }
@@ -74,11 +74,11 @@
               "Value": {
                 "type": "object",
                 "properties": {
-                  "ShrId": { "type": "string" },
-                  "EntryType": { "type": "string" },
-                  "EntryId": { "type": "string" }
+                  "_ShrId": { "type": "string" },
+                  "_EntryType": { "type": "string" },
+                  "_EntryId": { "type": "string" }
                 },
-                "required": ["ShrId", "EntryType", "EntryId"],
+                "required": ["_ShrId", "_EntryType", "_EntryId"],
                 "refType": ["http://standardhealthrecord.org/spec/shr/test/Simple"]
               }
             },

--- a/test/fixtures/TypeConstraints.schema.json
+++ b/test/fixtures/TypeConstraints.schema.json
@@ -21,8 +21,8 @@
           {
             "type": "object",
             "properties": {
-              "shr.test.Simple": { "$ref": "#/definitions/SimpleChild" },
-              "shr.test.ElementValue": {
+              "Simple": { "$ref": "#/definitions/SimpleChild" },
+              "ElementValue": {
                 "type": "array",
                 "minItems": 0,
                 "items": {
@@ -32,7 +32,7 @@
                 }
               }
             },
-            "required": ["shr.test.Simple"]
+            "required": ["Simple"]
           }
         ]
       },
@@ -47,15 +47,15 @@
           {
             "type": "object",
             "properties": {
-              "shr.test.Simple": { "$ref": "#/definitions/Simple" },
-              "shr.test.Coded": { "$ref": "#/definitions/Coded" },
-              "shr.test.ElementValue": {
+              "Simple": { "$ref": "#/definitions/Simple" },
+              "Coded": { "$ref": "#/definitions/Coded" },
+              "ElementValue": {
                 "type": "array",
                 "minItems": 0,
                 "items": { "$ref": "#/definitions/ElementValue" }
               }
             },
-            "required": ["shr.test.Simple"]
+            "required": ["Simple"]
           }
         ]
       },

--- a/test/fixtures/TypeConstraintsWithPath.schema.json
+++ b/test/fixtures/TypeConstraintsWithPath.schema.json
@@ -21,11 +21,11 @@
           {
             "type": "object",
             "properties": {
-              "shr.test.TwoDeepElementField": {
+              "TwoDeepElementField": {
                 "properties": {
-                  "shr.test.ElementField": {
+                  "ElementField": {
                     "properties": {
-                      "shr.test.Simple": { "$ref": "#/definitions/SimpleChild" }
+                      "Simple": { "$ref": "#/definitions/SimpleChild" }
                     }
                   }
                 }
@@ -41,13 +41,13 @@
           {
             "type": "object",
             "properties": {
-              "shr.test.TwoDeepElementField": {
+              "TwoDeepElementField": {
                 "allOf": [
                   {
                     "properties": {
-                      "shr.test.ElementField": {
+                      "ElementField": {
                         "properties": {
-                          "shr.test.Simple": { "$ref": "#/definitions/SimpleChild" }
+                          "Simple": { "$ref": "#/definitions/SimpleChild" }
                         }
                       }
                     }
@@ -66,7 +66,7 @@
           {
             "type": "object",
             "properties": {
-              "shr.test.TwoDeepElementField": {
+              "TwoDeepElementField": {
                 "$ref": "#/definitions/TwoDeepElementField"
               }
             }
@@ -80,11 +80,11 @@
           {
             "type": "object",
             "properties": {
-              "shr.test.ElementField": {
+              "ElementField": {
                 "$ref": "#/definitions/ElementField"
               }
             },
-            "required": ["shr.test.ElementField"]
+            "required": ["ElementField"]
           }
         ]
       },
@@ -95,9 +95,9 @@
           {
             "type": "object",
             "properties": {
-              "shr.test.Simple": { "$ref": "#/definitions/Simple" }
+              "Simple": { "$ref": "#/definitions/Simple" }
             },
-            "required": ["shr.test.Simple"]
+            "required": ["Simple"]
           }
         ]
       },

--- a/test/fixtures/instances/ChoiceOfChoice.json
+++ b/test/fixtures/instances/ChoiceOfChoice.json
@@ -1,8 +1,8 @@
 {
-  "shr.base.ShrId": { "Value": "patient-id", "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId"} },
-  "shr.base.EntryId": { "Value": "my-id", "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId"} },
-  "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/test/ChoiceOfChoice"},
-  "shr.core.CreationTime": { "Value": "2017-11-30T12:34:56Z", "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"} },
-  "shr.base.LastUpdated": { "Value": "2017-11-30T12:34:56Z", "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"} },
+  "ShrId": { "Value": "patient-id", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId"} },
+  "EntryId": { "Value": "my-id", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId"} },
+  "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/test/ChoiceOfChoice"},
+  "CreationTime": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"} },
+  "LastUpdated": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"} },
   "Value": 35
 }

--- a/test/fixtures/instances/Coded.json
+++ b/test/fixtures/instances/Coded.json
@@ -1,8 +1,8 @@
 {
-  "shr.base.ShrId": { "Value": "patient-id", "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId"} },
-  "shr.base.EntryId": { "Value": "my-id", "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId"} },
-  "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/test/Coded"},
-  "shr.core.CreationTime": { "Value": "2017-11-30T12:34:56Z", "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"} },
-  "shr.base.LastUpdated": { "Value": "2017-11-30T12:34:56Z", "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"} },
+  "ShrId": { "Value": "patient-id", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId"} },
+  "EntryId": { "Value": "my-id", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId"} },
+  "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/test/Coded"},
+  "CreationTime": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"} },
+  "LastUpdated": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"} },
   "Value": { "code": "bar", "codeSystem": "urn:some-namespace:foo" }
 }

--- a/test/fixtures/instances/NestedCardConstraint.json
+++ b/test/fixtures/instances/NestedCardConstraint.json
@@ -1,13 +1,13 @@
 {
-  "shr.base.ShrId": { "Value": "patient-id", "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId"} },
-  "shr.base.EntryId": { "Value": "my-id-3", "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId"} },
-  "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/test/NestedCardConstraint"},
-  "shr.core.CreationTime": { "Value": "2017-11-30T12:34:56Z", "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"} },
-  "shr.base.LastUpdated": { "Value": "2017-11-30T12:34:56Z", "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"} },
-  "shr.test.OptionalField": {
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/test/OptionalField"},
-    "shr.test.OptionalValue": {
-      "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/test/OptionalValue"},
+  "ShrId": { "Value": "patient-id", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId"} },
+  "EntryId": { "Value": "my-id-3", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId"} },
+  "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/test/NestedCardConstraint"},
+  "CreationTime": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"} },
+  "LastUpdated": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"} },
+  "OptionalField": {
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/test/OptionalField"},
+    "OptionalValue": {
+      "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/test/OptionalValue"},
       "comment": "The value is optional."
     }
   }

--- a/test/fixtures/instances/Simple.json
+++ b/test/fixtures/instances/Simple.json
@@ -1,8 +1,8 @@
 {
-  "shr.base.ShrId": { "Value": "patient-id", "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId"} },
-  "shr.base.EntryId": { "Value": "my-id", "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId"} },
-  "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/test/Simple"},
-  "shr.core.CreationTime": { "Value": "2017-11-30T12:34:56Z", "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"} },
-  "shr.base.LastUpdated": { "Value": "2017-11-30T12:34:56Z", "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"} },
+  "ShrId": { "Value": "patient-id", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId"} },
+  "EntryId": { "Value": "my-id", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId"} },
+  "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/test/Simple"},
+  "CreationTime": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"} },
+  "LastUpdated": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"} },
   "Value": "Hello World!"
 }

--- a/test/fixtures/instances/SimpleReference.json
+++ b/test/fixtures/instances/SimpleReference.json
@@ -1,9 +1,9 @@
 {
-  "shr.base.ShrId": { "Value": "patient-id", "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId"} },
-  "shr.base.EntryId": { "Value": "my-id", "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId"} },
-  "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/test/SimpleReference"},
-  "shr.core.CreationTime": { "Value": "2017-11-30T12:34:56Z", "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"} },
-  "shr.base.LastUpdated": { "Value": "2017-11-30T12:34:56Z", "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"} },
+  "ShrId": { "Value": "patient-id", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId"} },
+  "EntryId": { "Value": "my-id", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId"} },
+  "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/test/SimpleReference"},
+  "CreationTime": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"} },
+  "LastUpdated": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"} },
   "Value": {
     "ShrId": "patient-id",
     "EntryId": "another-id",

--- a/test/fixtures/instances/SimpleReference.json
+++ b/test/fixtures/instances/SimpleReference.json
@@ -5,8 +5,8 @@
   "CreationTime": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"} },
   "LastUpdated": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"} },
   "Value": {
-    "ShrId": "patient-id",
-    "EntryId": "another-id",
-    "EntryType": "http://standardhealthrecord.org/spec/shr/test/Simple"
+    "_ShrId": "patient-id",
+    "_EntryId": "another-id",
+    "_EntryType": "http://standardhealthrecord.org/spec/shr/test/Simple"
   }
 }

--- a/test/fixtures/instances/TwoDeepElementValue.json
+++ b/test/fixtures/instances/TwoDeepElementValue.json
@@ -1,21 +1,21 @@
 {
-  "shr.base.ShrId": { "Value": "patient-id", "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId"} },
-  "shr.base.EntryId": { "Value": "my-id-3", "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId"} },
-  "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/test/TwoDeepElementValue"},
-  "shr.core.CreationTime": { "Value": "2017-11-30T12:34:56Z", "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"} },
-  "shr.base.LastUpdated": { "Value": "2017-11-30T12:34:56Z", "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"} },
+  "ShrId": { "Value": "patient-id", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId"} },
+  "EntryId": { "Value": "my-id-3", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId"} },
+  "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/test/TwoDeepElementValue"},
+  "CreationTime": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"} },
+  "LastUpdated": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"} },
   "Value": {
-    "shr.base.ShrId": { "Value": "patient-id", "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId"} },
-    "shr.base.EntryId": { "Value": "my-id-2", "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId"}  },
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/test/ElementValue"},
-    "shr.core.CreationTime": { "Value": "2017-11-30T12:34:56Z", "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"} },
-    "shr.base.LastUpdated": { "Value": "2017-11-30T12:34:56Z", "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"} },
+    "ShrId": { "Value": "patient-id", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId"} },
+    "EntryId": { "Value": "my-id-2", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId"}  },
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/test/ElementValue"},
+    "CreationTime": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"} },
+    "LastUpdated": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"} },
     "Value": {
-      "shr.base.ShrId": { "Value": "patient-id", "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId"} },
-      "shr.base.EntryId": { "Value": "my-id", "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId"} },
-      "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/test/Simple"},
-      "shr.core.CreationTime": { "Value": "2017-11-30T12:34:56Z", "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"} },
-      "shr.base.LastUpdated": { "Value": "2017-11-30T12:34:56Z", "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"} },
+      "ShrId": { "Value": "patient-id", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId"} },
+      "EntryId": { "Value": "my-id", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId"} },
+      "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/test/Simple"},
+      "CreationTime": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"} },
+      "LastUpdated": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"} },
       "Value": "I'm nested pretty deep."
     }
   }

--- a/test/fixtures/instances/TypeConstrainedReference.json
+++ b/test/fixtures/instances/TypeConstrainedReference.json
@@ -1,9 +1,9 @@
 {
-  "shr.base.ShrId": { "Value": "patient-id", "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId"} },
-  "shr.base.EntryId": { "Value": "my-id", "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId"} },
-  "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/test/TypeConstrainedReference"},
-  "shr.core.CreationTime": { "Value": "2017-11-30T12:34:56Z", "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"} },
-  "shr.base.LastUpdated": { "Value": "2017-11-30T12:34:56Z", "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"} },
+  "ShrId": { "Value": "patient-id", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId"} },
+  "EntryId": { "Value": "my-id", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId"} },
+  "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/test/TypeConstrainedReference"},
+  "CreationTime": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"} },
+  "LastUpdated": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"} },
   "Value": {
     "ShrId": "patient-id",
     "EntryId": "another-id-2",

--- a/test/fixtures/instances/TypeConstrainedReference.json
+++ b/test/fixtures/instances/TypeConstrainedReference.json
@@ -5,8 +5,8 @@
   "CreationTime": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"} },
   "LastUpdated": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"} },
   "Value": {
-    "ShrId": "patient-id",
-    "EntryId": "another-id-2",
-    "EntryType": "http://standardhealthrecord.org/spec/shr/test/SimpleChild"
+    "_ShrId": "patient-id",
+    "_EntryId": "another-id-2",
+    "_EntryType": "http://standardhealthrecord.org/spec/shr/test/SimpleChild"
   }
 }

--- a/test/fixtures/instances/TypeConstraints.json
+++ b/test/fixtures/instances/TypeConstraints.json
@@ -1,45 +1,45 @@
 {
-  "shr.base.ShrId": { "Value": "patient-id", "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId"} },
-  "shr.base.EntryId": { "Value": "my-id", "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId"} },
-  "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/test/GroupDerivative"},
-  "shr.core.CreationTime": { "Value": "2017-11-30T12:34:56Z", "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"} },
-  "shr.base.LastUpdated": { "Value": "2017-11-30T12:34:56Z", "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"} },
-  "shr.test.Simple": {
-    "shr.base.ShrId": { "Value": "patient-id", "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId"} },
-    "shr.base.EntryId": { "Value": "my-id-2", "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId"} },
-    "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/test/SimpleChild"},
-    "shr.core.CreationTime": { "Value": "2017-11-30T12:34:56Z", "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"} },
-    "shr.base.LastUpdated": { "Value": "2017-11-30T12:34:56Z", "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"} },
+  "ShrId": { "Value": "patient-id", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId"} },
+  "EntryId": { "Value": "my-id", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId"} },
+  "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/test/GroupDerivative"},
+  "CreationTime": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"} },
+  "LastUpdated": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"} },
+  "Simple": {
+    "ShrId": { "Value": "patient-id", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId"} },
+    "EntryId": { "Value": "my-id-2", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId"} },
+    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/test/SimpleChild"},
+    "CreationTime": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"} },
+    "LastUpdated": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"} },
     "Value": "I'm nested pretty deep."
   },
-  "shr.test.ElementValue": [
+  "ElementValue": [
     {
-      "shr.base.ShrId": { "Value": "patient-id", "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId"} },
-      "shr.base.EntryId": { "Value": "my-id-3", "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId"} },
-      "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/test/ElementValue"},
-      "shr.core.CreationTime": { "Value": "2017-11-30T12:34:56Z", "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"} },
-      "shr.base.LastUpdated": { "Value": "2017-11-30T12:34:56Z", "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"} },
+      "ShrId": { "Value": "patient-id", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId"} },
+      "EntryId": { "Value": "my-id-3", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId"} },
+      "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/test/ElementValue"},
+      "CreationTime": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"} },
+      "LastUpdated": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"} },
       "Value": {
-        "shr.base.ShrId": { "Value": "patient-id", "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId"} },
-        "shr.base.EntryId": { "Value": "my-id-4", "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId"} },
-        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/test/SimpleChild"},
-        "shr.core.CreationTime": { "Value": "2017-11-30T12:34:56Z", "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"} },
-        "shr.base.LastUpdated": { "Value": "2017-11-30T12:34:56Z", "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"} },
+        "ShrId": { "Value": "patient-id", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId"} },
+        "EntryId": { "Value": "my-id-4", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId"} },
+        "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/test/SimpleChild"},
+        "CreationTime": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"} },
+        "LastUpdated": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"} },
         "Value": "I'm the first child."
       }
     },
     {
-      "shr.base.ShrId": { "Value": "patient-id", "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId"} },
-      "shr.base.EntryId": { "Value": "my-id-5", "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId"} },
-      "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/test/ElementValue"},
-      "shr.core.CreationTime": { "Value": "2017-11-30T12:34:56Z", "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"} },
-      "shr.base.LastUpdated": { "Value": "2017-11-30T12:34:56Z", "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"} },
+      "ShrId": { "Value": "patient-id", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId"} },
+      "EntryId": { "Value": "my-id-5", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId"} },
+      "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/test/ElementValue"},
+      "CreationTime": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"} },
+      "LastUpdated": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"} },
       "Value": {
-        "shr.base.ShrId": { "Value": "patient-id", "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId"} },
-        "shr.base.EntryId": { "Value": "my-id-6", "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId"} },
-        "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/test/SimpleChild"},
-        "shr.core.CreationTime": { "Value": "2017-11-30T12:34:56Z", "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"} },
-        "shr.base.LastUpdated": { "Value": "2017-11-30T12:34:56Z", "shr.base.EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"} },
+        "ShrId": { "Value": "patient-id", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId"} },
+        "EntryId": { "Value": "my-id-6", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId"} },
+        "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/test/SimpleChild"},
+        "CreationTime": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"} },
+        "LastUpdated": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"} },
         "Value": "I'm the second child."
       }
     }


### PR DESCRIPTION
This removes namespaces from the element properties in the JSON Schema as previously discussed.