### PR TITLE
Fix Crash / Error

### DIFF
--- a/lib/export.js
+++ b/lib/export.js
@@ -613,11 +613,11 @@ function convertDefinition(valueDef, dataElementsSpecs, enclosingNamespace, base
                   arrayDef.maxItems = constraintInfo.constraint.card.max;
                 }
                 currentAllOf.push(arrayDef);
-                if (constraintInfo.constraint.card.min) {
+                if (parentAllOf && constraintInfo.constraint.card.min) {
                   parentAllOf.push({ required: [constraintInfo.constraintPath[constraintInfo.constraintPath.length - 1]] });
                 }
               } else {
-                if (constraintInfo.constraint.card.min) {
+                if (parentAllOf && constraintInfo.constraint.card.min) {
                   parentAllOf.push({ required: [constraintInfo.constraintPath[constraintInfo.constraintPath.length - 1]] });
                 }
               }
@@ -1074,8 +1074,16 @@ function isOrWasAList(value) {
  * @returns {Value?} The first option in the choice that matches the specified optionId.
  */
 function findOptionInChoice(choice, optionId, dataElementSpecs) {
+  // First look for a direct match
   for (const option of choice.aggregateOptions) {
-    if (optionId.equals(option.identifier) || checkHasBaseType(option.identifier, optionId, dataElementSpecs)) {
+    if (optionId.equals(option.identifier)) {
+      return option;
+    }
+  }
+  // Then look for a match on one of the selected options's base types
+  // E.g., if choice has Quantity but selected option is IntegerQuantity
+  for (const option of choice.aggregateOptions) {
+    if (checkHasBaseType(optionId, option.identifier, dataElementSpecs)) {
       return option;
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-json-schema-export",
-  "version": "5.3.1",
+  "version": "5.3.2",
   "description": "Exports SHR data elements from SHR models to JSON Schema",
   "author": "",
   "license": "Apache-2.0",


### PR DESCRIPTION
This PR fixes a crash when trying to set required properties on a non-existing parent.  It also fixes logic to look at base types of the selected option when trying to find it in a choice.

This branch is called `dstu2` because the bugs were discovered and fixed while working on DSTU2 support, but it is not actually related to DSTU2 support.

Without this fix, you will likely only see the FATAL error (crash) -- because the second error isn't reached before the exporter crashes.