### PR TITLE
CIMPL6 Import

### DIFF
--- a/lib/export.js
+++ b/lib/export.js
@@ -3,9 +3,7 @@
 // Derived from export SHR specification content as a hierarchy in JSON format by Greg Quinn
 
 const bunyan = require('bunyan');
-const {Identifier, IdentifiableValue, RefValue, ChoiceValue, TBD, IncompleteValue, ValueSetConstraint, IncludesCodeConstraint, IncludesTypeConstraint, CodeConstraint, CardConstraint, TypeConstraint, INHERITED, OVERRIDDEN, DataElement, Namespace, DataElementSpecifications, Specifications, BooleanConstraint, MODELS_INFO, PrimitiveIdentifier, PRIMITIVE_NS} = require('shr-models');
-
-const CONCEPT = new PrimitiveIdentifier('concept');
+const {Identifier, IdentifiableValue, RefValue, ChoiceValue, TBD, IncompleteValue, ValueSetConstraint, IncludesCodeConstraint, IncludesTypeConstraint, CodeConstraint, CardConstraint, TypeConstraint, INHERITED, OVERRIDDEN, BooleanConstraint, MODELS_INFO, PRIMITIVE_NS} = require('shr-models');
 
 var rootLogger = bunyan.createLogger({name: 'shr-json-schema-export'});
 var logger = rootLogger;
@@ -63,7 +61,7 @@ function namespaceToSchema(ns, dataElementsSpecs, baseSchemaURL, baseTypeURL) {
   let schema = {
     $schema: 'http://json-schema.org/draft-04/schema#',
     id: schemaId,
-    title: "TODO: Figure out what the title should be.",
+    title: 'TODO: Figure out what the title should be.',
     definitions: {}
   };
   const entryRef = makeRef(new Identifier('shr.base', 'Entry'), ns, baseSchemaURL);
@@ -242,7 +240,7 @@ function flatNamespaceToSchema(ns, dataElementsSpecs, baseSchemaURL, baseTypeURL
   let schema = {
     $schema: 'http://json-schema.org/draft-04/schema#',
     id: schemaId,
-    title: "TODO: Figure out what the title should be.",
+    title: 'TODO: Figure out what the title should be.',
     definitions: {}
   };
   const expandedEntry = makeExpandedEntryDefinitions(ns, baseSchemaURL);
@@ -521,153 +519,154 @@ function convertDefinition(valueDef, dataElementsSpecs, enclosingNamespace, base
     }
   }
 
-  if (valueDef.constraints && valueDef.constraints.length) {
-    function constraintDfs (node, currentAllOf, parentAllOf = null) {
-      for (const path in node) {
-        if (path !== '$self') {
-          if (!currentAllOf[0].properties[path]) {
-            currentAllOf[0].properties[path] = {
-              allOf: [
-                { properties: {} }
-              ]
-            };
-          }
-          constraintDfs(node[path], currentAllOf[0].properties[path].allOf, currentAllOf);
-        } else {
-          currentAllOf[0].constraints = [];
-          let includesConstraints = null;
-          let includesCodeConstraints = null;
-          for (const constraintInfo of node.$self) {
-            if (constraintInfo.constraint instanceof TypeConstraint) {
-              if (constraintInfo.constraintTarget instanceof RefValue) {
-                const refid = constraintInfo.constraint.isA;
-                if (isOrWasAList(constraintInfo.constraintTarget)) {
-                  currentAllOf.push({ items: { refType: [`${baseTypeURL}${namespaceToURLPathSegment(refid.namespace)}/${refid.name}`]}});
-                } else {
-                  currentAllOf.push({ refType: [`${baseTypeURL}${namespaceToURLPathSegment(refid.namespace)}/${refid.name}`]});
-                }
-              } else if (constraintInfo.constraintTarget instanceof IdentifiableValue) {
-                let schemaConstraint = null;
-                if (constraintInfo.constraint.isA.isPrimitive) {
-                  schemaConstraint = makePrimitiveObject(constraintInfo.constraint.isA);
-                } else {
-                  schemaConstraint = {$ref: makeRef(constraintInfo.constraint.isA, enclosingNamespace, baseSchemaURL)};
-                }
-                if (isOrWasAList(constraintInfo.constraintTarget)) {
-                  currentAllOf.push({ items: schemaConstraint });
-                } else {
-                  currentAllOf.push(schemaConstraint);
-                }
-              } else {
-                logger.error('Internal error unexpected constraint target: %s for constraint %s', constraintInfo.constraintTarget.toString(), constraintInfo.constraint.toString());
-              }
-            } else if (constraintInfo.constraint instanceof IncludesTypeConstraint) {
-              if (!includesConstraints) {
-                includesConstraints = {refs: [], types: [], min: 0, max: 0};
-              }
-              includesConstraints.min += constraintInfo.constraint.card.min;
-              if (includesConstraints.max !== null) {
-                if (constraintInfo.constraint.card.isMaxUnbounded) {
-                  includesConstraints.max = null;
-                } else {
-                  includesConstraints.max += constraintInfo.constraint.card.max;
-                }
-              }
-
-              if (constraintInfo.constraint.isA instanceof RefValue) {
-                includesConstraints.refs.push(constraintInfo.constraint);
-              } else {
-                includesConstraints.types.push(constraintInfo.constraint);
-              }
-            } else if (constraintInfo.constraint instanceof IncludesCodeConstraint) {
-              if (!includesCodeConstraints) {
-                includesCodeConstraints = [];
-              }
-              includesCodeConstraints.push(constraintInfo.constraint);
-            } else if (constraintInfo.constraint instanceof ValueSetConstraint) {
-              if (currentAllOf[0].valueSet) {
-                logger.error(`Multiple valueset constraints found on a single element %s.`, constraintInfo.constraint);
-                continue;
-              }
-              currentAllOf[0].valueSet = {
-                uri: constraintInfo.constraint.valueSet,
-                strength: constraintInfo.constraint.bindingStrength
-              };
-            } else if (constraintInfo.constraint instanceof CodeConstraint) {
-              // Maybe TODO: For entry elements this can have some level of enforcement by ANDing the exact contents of the EntryType field with an enum for this value/field.
-              if (currentAllOf[0].code) {
-                logger.error(`Multiple code constraints found on a single element %s.`, constraintInfo.constraint);
-                continue;
-              }
-              currentAllOf[0].code = makeConceptEntry(constraintInfo.constraint.code);
-            } else if (constraintInfo.constraint instanceof BooleanConstraint) {
-              currentAllOf.push({ enum: [constraintInfo.constraint.value]});
-            } else if (constraintInfo.constraint instanceof CardConstraint) {
-              // TODO: 0..0
+  function constraintDfs (node, currentAllOf, parentAllOf = null) {
+    for (const path in node) {
+      if (path !== '$self') {
+        if (!currentAllOf[0].properties[path]) {
+          currentAllOf[0].properties[path] = {
+            allOf: [
+              { properties: {} }
+            ]
+          };
+        }
+        constraintDfs(node[path], currentAllOf[0].properties[path].allOf, currentAllOf);
+      } else {
+        currentAllOf[0].constraints = [];
+        let includesConstraints = null;
+        let includesCodeConstraints = null;
+        for (const constraintInfo of node.$self) {
+          if (constraintInfo.constraint instanceof TypeConstraint) {
+            if (constraintInfo.constraintTarget instanceof RefValue) {
+              const refid = constraintInfo.constraint.isA;
               if (isOrWasAList(constraintInfo.constraintTarget)) {
-                const arrayDef = {
-                  type: 'array',
-                  minItems: constraintInfo.constraint.card.min,
-                };
-                if (constraintInfo.constraint.card.max) {
-                  arrayDef.maxItems = constraintInfo.constraint.card.max;
-                }
-                currentAllOf.push(arrayDef);
-                if (parentAllOf && constraintInfo.constraint.card.min) {
-                  parentAllOf.push({ required: [constraintInfo.constraintPath[constraintInfo.constraintPath.length - 1]] });
-                }
+                currentAllOf.push({ items: { refType: [`${baseTypeURL}${namespaceToURLPathSegment(refid.namespace)}/${refid.name}`]}});
               } else {
-                if (parentAllOf && constraintInfo.constraint.card.min) {
-                  parentAllOf.push({ required: [constraintInfo.constraintPath[constraintInfo.constraintPath.length - 1]] });
-                }
+                currentAllOf.push({ refType: [`${baseTypeURL}${namespaceToURLPathSegment(refid.namespace)}/${refid.name}`]});
+              }
+            } else if (constraintInfo.constraintTarget instanceof IdentifiableValue) {
+              let schemaConstraint = null;
+              if (constraintInfo.constraint.isA.isPrimitive) {
+                schemaConstraint = makePrimitiveObject(constraintInfo.constraint.isA);
+              } else {
+                schemaConstraint = {$ref: makeRef(constraintInfo.constraint.isA, enclosingNamespace, baseSchemaURL)};
+              }
+              if (isOrWasAList(constraintInfo.constraintTarget)) {
+                currentAllOf.push({ items: schemaConstraint });
+              } else {
+                currentAllOf.push(schemaConstraint);
               }
             } else {
-              currentAllOf[0].constraints.push(constraintInfo.constraint);
+              logger.error('Internal error unexpected constraint target: %s for constraint %s', constraintInfo.constraintTarget.toString(), constraintInfo.constraint.toString());
             }
-          }
-
-          if (includesConstraints) {
-            currentAllOf[0].includesTypes = [];
-            const includesTypesArrayDef = {
-              type: 'array',
-              minItems: includesConstraints.min,
-              items: { anyOf: [] }
-            };
-            currentAllOf.push(includesTypesArrayDef);
+          } else if (constraintInfo.constraint instanceof IncludesTypeConstraint) {
+            if (!includesConstraints) {
+              includesConstraints = {refs: [], types: [], min: 0, max: 0};
+            }
+            includesConstraints.min += constraintInfo.constraint.card.min;
             if (includesConstraints.max !== null) {
-              includesTypesArrayDef.maxItems = includesConstraints.max;
-            }
-            if (includesConstraints.refs.length) {
-              includesTypesArrayDef.items.anyOf.push(makeShrRefObject(includesConstraints.refs.map((ref) => ref.isA), baseTypeURL));
-              for (const ref of includesConstraints.refs) {
-                const includesType = {
-                  items: `ref(${makeShrDefinitionURL(ref.isA, baseSchemaURL)})`,
-                  minItems: ref.card.min
-                };
-                if (!ref.card.isMaxUnbounded) {
-                  includesType.maxItems = ref.card.max;
-                }
-                currentAllOf[0].includesTypes.push(includesType);
+              if (constraintInfo.constraint.card.isMaxUnbounded) {
+                includesConstraints.max = null;
+              } else {
+                includesConstraints.max += constraintInfo.constraint.card.max;
               }
             }
-            for (const val of includesConstraints.types) {
-              includesTypesArrayDef.items.anyOf.push({ $ref: makeRef(val.isA, enclosingNamespace, baseSchemaURL) });
-              const includesType = {
-                items: `${baseTypeURL}${namespaceToURLPathSegment(val.isA.namespace)}/${val.isA.name}`,
-                minItems: val.card.min
+
+            if (constraintInfo.constraint.isA instanceof RefValue) {
+              includesConstraints.refs.push(constraintInfo.constraint);
+            } else {
+              includesConstraints.types.push(constraintInfo.constraint);
+            }
+          } else if (constraintInfo.constraint instanceof IncludesCodeConstraint) {
+            if (!includesCodeConstraints) {
+              includesCodeConstraints = [];
+            }
+            includesCodeConstraints.push(constraintInfo.constraint);
+          } else if (constraintInfo.constraint instanceof ValueSetConstraint) {
+            if (currentAllOf[0].valueSet) {
+              logger.error(`Multiple valueset constraints found on a single element %s.`, constraintInfo.constraint);
+              continue;
+            }
+            currentAllOf[0].valueSet = {
+              uri: constraintInfo.constraint.valueSet,
+              strength: constraintInfo.constraint.bindingStrength
+            };
+          } else if (constraintInfo.constraint instanceof CodeConstraint) {
+            // Maybe TODO: For entry elements this can have some level of enforcement by ANDing the exact contents of the EntryType field with an enum for this value/field.
+            if (currentAllOf[0].code) {
+              logger.error(`Multiple code constraints found on a single element %s.`, constraintInfo.constraint);
+              continue;
+            }
+            currentAllOf[0].code = makeConceptEntry(constraintInfo.constraint.code);
+          } else if (constraintInfo.constraint instanceof BooleanConstraint) {
+            currentAllOf.push({ enum: [constraintInfo.constraint.value]});
+          } else if (constraintInfo.constraint instanceof CardConstraint) {
+            // TODO: 0..0
+            if (isOrWasAList(constraintInfo.constraintTarget)) {
+              const arrayDef = {
+                type: 'array',
+                minItems: constraintInfo.constraint.card.min,
               };
-              if (!val.card.isMaxUnbounded) {
-                includesType.maxItems = val.card.max;
+              if (constraintInfo.constraint.card.max) {
+                arrayDef.maxItems = constraintInfo.constraint.card.max;
+              }
+              currentAllOf.push(arrayDef);
+              if (parentAllOf && constraintInfo.constraint.card.min) {
+                parentAllOf.push({ required: [constraintInfo.constraintPath[constraintInfo.constraintPath.length - 1]] });
+              }
+            } else {
+              if (parentAllOf && constraintInfo.constraint.card.min) {
+                parentAllOf.push({ required: [constraintInfo.constraintPath[constraintInfo.constraintPath.length - 1]] });
+              }
+            }
+          } else {
+            currentAllOf[0].constraints.push(constraintInfo.constraint);
+          }
+        }
+
+        if (includesConstraints) {
+          currentAllOf[0].includesTypes = [];
+          const includesTypesArrayDef = {
+            type: 'array',
+            minItems: includesConstraints.min,
+            items: { anyOf: [] }
+          };
+          currentAllOf.push(includesTypesArrayDef);
+          if (includesConstraints.max !== null) {
+            includesTypesArrayDef.maxItems = includesConstraints.max;
+          }
+          if (includesConstraints.refs.length) {
+            includesTypesArrayDef.items.anyOf.push(makeShrRefObject(includesConstraints.refs.map((ref) => ref.isA), baseTypeURL));
+            for (const ref of includesConstraints.refs) {
+              const includesType = {
+                items: `ref(${makeShrDefinitionURL(ref.isA, baseSchemaURL)})`,
+                minItems: ref.card.min
+              };
+              if (!ref.card.isMaxUnbounded) {
+                includesType.maxItems = ref.card.max;
               }
               currentAllOf[0].includesTypes.push(includesType);
             }
           }
-          if (includesCodeConstraints) {
-            currentAllOf[0].includesCodes = includesCodeConstraints.map((it) => makeConceptEntry(it.code));
+          for (const val of includesConstraints.types) {
+            includesTypesArrayDef.items.anyOf.push({ $ref: makeRef(val.isA, enclosingNamespace, baseSchemaURL) });
+            const includesType = {
+              items: `${baseTypeURL}${namespaceToURLPathSegment(val.isA.namespace)}/${val.isA.name}`,
+              minItems: val.card.min
+            };
+            if (!val.card.isMaxUnbounded) {
+              includesType.maxItems = val.card.max;
+            }
+            currentAllOf[0].includesTypes.push(includesType);
           }
+        }
+        if (includesCodeConstraints) {
+          currentAllOf[0].includesCodes = includesCodeConstraints.map((it) => makeConceptEntry(it.code));
         }
       }
     }
+  }
+
+  if (valueDef.constraints && valueDef.constraints.length) {
     constraintDfs(constraintStructure, allOf);
     if (isList) {
       for (const includesConstraintDef of allOf) {
@@ -1088,35 +1087,6 @@ function findOptionInChoice(choice, optionId, dataElementSpecs) {
     }
   }
   return null;
-}
-
-// stealing from shr-expand
-/**
- * Determine if a type supports a code constraint.
- *
- * @param {Identifier} identifier - The identifier of the type to check.
- * @param {DataElementSpecifications} dataElementSpecs - The available DataElement specs.
- * @return {boolean} Whether or not the given type supports a code constraint.
- */
-function supportsCodeConstraint(identifier, dataElementSpecs) {
-  if (CONCEPT.equals(identifier)) {
-    return true;
-  }
-  const element = dataElementSpecs.findByIdentifier(identifier);
-  if (element.value) {
-    if (element.value instanceof IdentifiableValue) {
-      return CONCEPT.equals(element.value.identifier);
-    } else if (element.value instanceof ChoiceValue) {
-      for (const value of element.value.aggregateOptions) {
-        if (value instanceof IdentifiableValue) {
-          if (CONCEPT.equals(value.identifier)) {
-            return true;
-          }
-        }
-      }
-    }
-  }
-  return false;
 }
 
 function checkHasBaseType(identifier, baseIdentifier, dataElementSpecs) {

--- a/lib/export.js
+++ b/lib/export.js
@@ -3,7 +3,7 @@
 // Derived from export SHR specification content as a hierarchy in JSON format by Greg Quinn
 
 const bunyan = require('bunyan');
-const {Identifier, IdentifiableValue, RefValue, ChoiceValue, TBD, IncompleteValue, ValueSetConstraint, IncludesCodeConstraint, IncludesTypeConstraint, CodeConstraint, CardConstraint, TypeConstraint, INHERITED, OVERRIDDEN, BooleanConstraint, MODELS_INFO, PRIMITIVE_NS} = require('shr-models');
+const {Identifier, IdentifiableValue, ChoiceValue, TBD, IncompleteValue, ValueSetConstraint, IncludesCodeConstraint, IncludesTypeConstraint, CodeConstraint, CardConstraint, TypeConstraint, INHERITED, OVERRIDDEN, BooleanConstraint, MODELS_INFO, PRIMITIVE_NS} = require('shr-models');
 
 var rootLogger = bunyan.createLogger({name: 'shr-json-schema-export'});
 var logger = rootLogger;
@@ -397,7 +397,7 @@ function convertDefinition(valueDef, dataElementsSpecs, enclosingNamespace, base
     for (const option of valueDef.options) {
       if (option.effectiveCard && (!option.effectiveCard.isExactlyOne)) {
         logger.error('Choices with options with cardinalities that are not exactly one are illegal "%s". Ignoring option %s.', valueDef.toString(), option.toString());
-      } else if (option instanceof RefValue) {
+      } else if (isRef(option, dataElementsSpecs)) {
         refOptions.push(option);
       } else {
         normalOptions.push(option);
@@ -418,7 +418,7 @@ function convertDefinition(valueDef, dataElementsSpecs, enclosingNamespace, base
         value[ent] = single[ent];
       }
     }
-  } else if (valueDef instanceof RefValue) {
+  } else if (isRef(valueDef, dataElementsSpecs)) {
     // TODO: What should the value of EntryType be? The schema URL may not be portable across data types.
     makeShrRefObject([valueDef], baseTypeURL, value);
   } else if (valueDef instanceof IdentifiableValue) {
@@ -536,7 +536,7 @@ function convertDefinition(valueDef, dataElementsSpecs, enclosingNamespace, base
         let includesCodeConstraints = null;
         for (const constraintInfo of node.$self) {
           if (constraintInfo.constraint instanceof TypeConstraint) {
-            if (constraintInfo.constraintTarget instanceof RefValue) {
+            if (isRef(constraintInfo.constraintTarget, dataElementsSpecs)) {
               const refid = constraintInfo.constraint.isA;
               if (isOrWasAList(constraintInfo.constraintTarget)) {
                 currentAllOf.push({ items: { refType: [`${baseTypeURL}${namespaceToURLPathSegment(refid.namespace)}/${refid.name}`]}});
@@ -571,7 +571,7 @@ function convertDefinition(valueDef, dataElementsSpecs, enclosingNamespace, base
               }
             }
 
-            if (constraintInfo.constraint.isA instanceof RefValue) {
+            if (isRef(constraintInfo.constraint.isA, dataElementsSpecs)) {
               includesConstraints.refs.push(constraintInfo.constraint);
             } else {
               includesConstraints.types.push(constraintInfo.constraint);
@@ -756,6 +756,14 @@ function tbdValueToString(tbd) {
       return 'TBD';
     }
   }
+}
+
+function isRef(value, dataElementsSpecs) {
+  if (value && value.effectiveIdentifier) {
+    const de = dataElementsSpecs.findByIdentifier(value.effectiveIdentifier);
+    return de && de.isEntry;
+  }
+  return false;
 }
 
 /**

--- a/lib/export.js
+++ b/lib/export.js
@@ -5,7 +5,7 @@
 const bunyan = require('bunyan');
 const {Identifier, IdentifiableValue, RefValue, ChoiceValue, TBD, IncompleteValue, ValueSetConstraint, IncludesCodeConstraint, IncludesTypeConstraint, CodeConstraint, CardConstraint, TypeConstraint, INHERITED, OVERRIDDEN, DataElement, Namespace, DataElementSpecifications, Specifications, BooleanConstraint, MODELS_INFO, PrimitiveIdentifier, PRIMITIVE_NS} = require('shr-models');
 
-const CODE = new PrimitiveIdentifier('code');
+const CONCEPT = new PrimitiveIdentifier('concept');
 
 var rootLogger = bunyan.createLogger({name: 'shr-json-schema-export'});
 var logger = rootLogger;
@@ -825,7 +825,7 @@ function makePrimitiveObject(id, target = {}) {
   case 'time':
     target.type = 'string';
     break;
-  case 'code':
+  case 'concept':
     target.type = 'object';
     target.properties = {
       code: { type: 'string' },
@@ -1030,7 +1030,7 @@ function makeExpandedEntryDefinitions(enclosingNamespace, baseSchemaURL) {
 }
 
 /**
- * Converts a concept into a code entry for the schema. (Codes are also represented as Concepts in the object model.)
+ * Converts a DataElement concept into a code entry for the schema. (Codes are also represented as Concepts in the object model.)
  *
  * @param {Concept|TBD} concept - The concept to convert.
  * @return {{code: string, codeSystem: string, displayText: (string|undefined)}} The converted object. Display is optional.
@@ -1099,20 +1099,17 @@ function findOptionInChoice(choice, optionId, dataElementSpecs) {
  * @return {boolean} Whether or not the given type supports a code constraint.
  */
 function supportsCodeConstraint(identifier, dataElementSpecs) {
-  if (CODE.equals(identifier) || checkHasBaseType(identifier, new Identifier('shr.core', 'Coding'), dataElementSpecs)
-      || checkHasBaseType(identifier, new Identifier('shr.core', 'CodeableConcept'), dataElementSpecs)) {
+  if (CONCEPT.equals(identifier)) {
     return true;
   }
   const element = dataElementSpecs.findByIdentifier(identifier);
   if (element.value) {
     if (element.value instanceof IdentifiableValue) {
-      return CODE.equals(element.value.identifier) || checkHasBaseType(element.value.identifier, new Identifier('shr.core', 'Coding'), dataElementSpecs)
-          || checkHasBaseType(element.value.identifier, new Identifier('shr.core', 'CodeableConcept'), dataElementSpecs);
+      return CONCEPT.equals(element.value.identifier);
     } else if (element.value instanceof ChoiceValue) {
       for (const value of element.value.aggregateOptions) {
         if (value instanceof IdentifiableValue) {
-          if (CODE.equals(value.identifier) || checkHasBaseType(value.identifier, new Identifier('shr.core', 'Coding'), dataElementSpecs)
-              || checkHasBaseType(value.identifier, new Identifier('shr.core', 'CodeableConcept'), dataElementSpecs)) {
+          if (CONCEPT.equals(value.identifier)) {
             return true;
           }
         }

--- a/lib/export.js
+++ b/lib/export.js
@@ -4,6 +4,7 @@
 
 const bunyan = require('bunyan');
 const {Identifier, IdentifiableValue, ChoiceValue, TBD, IncompleteValue, ValueSetConstraint, IncludesCodeConstraint, IncludesTypeConstraint, CodeConstraint, CardConstraint, TypeConstraint, INHERITED, OVERRIDDEN, BooleanConstraint, MODELS_INFO, PRIMITIVE_NS} = require('shr-models');
+const builtinSchema = require('./schemas/cimpl.builtin.schema.json');
 
 var rootLogger = bunyan.createLogger({name: 'shr-json-schema-export'});
 var logger = rootLogger;
@@ -21,7 +22,9 @@ function setLogger(bunyanLogger) {
  * @return {Object.<string, Object>} A mapping of schema ids to JSON Schema definitions.
  */
 function exportToJSONSchema(expSpecifications, baseSchemaURL, baseTypeURL, flat = false) {
-  const namespaceResults = {};
+  const namespaceResults = {
+    'https://standardhealthrecord.org/schema/cimpl/builtin': builtinSchema
+  };
   const endOfTypeURL = baseTypeURL[baseTypeURL.length - 1];
   if (endOfTypeURL !== '#' && endOfTypeURL !== '/') {
     baseTypeURL += '/';
@@ -596,7 +599,7 @@ function convertDefinition(valueDef, dataElementsSpecs, enclosingNamespace, base
               logger.error(`Multiple code constraints found on a single element %s.`, constraintInfo.constraint);
               continue;
             }
-            currentAllOf[0].code = makeConceptEntry(constraintInfo.constraint.code);
+            currentAllOf[0].code = makeCodingEntry(constraintInfo.constraint.code);
           } else if (constraintInfo.constraint instanceof BooleanConstraint) {
             currentAllOf.push({ enum: [constraintInfo.constraint.value]});
           } else if (constraintInfo.constraint instanceof CardConstraint) {
@@ -660,7 +663,7 @@ function convertDefinition(valueDef, dataElementsSpecs, enclosingNamespace, base
           }
         }
         if (includesCodeConstraints) {
-          currentAllOf[0].includesCodes = includesCodeConstraints.map((it) => makeConceptEntry(it.code));
+          currentAllOf[0].includesCodes = includesCodeConstraints.map((it) => makeCodingEntry(it.code));
         }
       }
     }
@@ -833,13 +836,7 @@ function makePrimitiveObject(id, target = {}) {
     target.type = 'string';
     break;
   case 'concept':
-    target.type = 'object';
-    target.properties = {
-      code: { type: 'string' },
-      codeSystem: { type: 'string', format: 'uri' },
-      displayText: { type: 'string' }
-    };
-    target.required = ['code', 'codeSystem'];
+    target['$ref'] = 'https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/Concept';
     break;
   case 'oid':
   case 'id':
@@ -1040,19 +1037,29 @@ function makeExpandedEntryDefinitions(enclosingNamespace, baseSchemaURL) {
  * Converts a DataElement concept into a code entry for the schema. (Codes are also represented as Concepts in the object model.)
  *
  * @param {Concept|TBD} concept - The concept to convert.
- * @return {{code: string, codeSystem: string, displayText: (string|undefined)}} The converted object. Display is optional.
+ * @return {{coding: List<{code: string, system: string, display: (string|undefined)}>}} The converted object. Display is optional.
  */
 function makeConceptEntry(concept) {
+  return { coding: [ makeCodingEntry(concept) ]};
+}
+
+/**
+ * Converts a concept into a coding entry for the schema (used in code constraints and includes code constraints)
+ *
+ * @param {Concept|TBD} concept - The concept to convert.
+ * @return {{code: string, system: string, display: (string|undefined)}} The converted object. Display is optional.
+ */
+function makeCodingEntry(concept) {
   if (concept instanceof TBD) {
-    const ret = { code: 'TBD', codeSystem: 'urn:tbd' };
+    const ret = { code: 'TBD', system: 'urn:tbd' };
     if (concept.text) {
-      ret.displayText = concept.text;
+      ret.display = concept.text;
     }
     return ret;
   } else {
-    const ret = { code: concept.code, codeSystem: concept.system };
+    const ret = { code: concept.code, system: concept.system };
     if (concept.display) {
-      ret.displayText = concept.display;
+      ret.display = concept.display;
     }
     return ret;
   }

--- a/lib/schemas/cimpl.builtin.schema.json
+++ b/lib/schemas/cimpl.builtin.schema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "https://standardhealthrecord.org/schema/cimpl/builtin",
+  "title": "CIMPL Builtin Schema",
+  "definitions": {
+    "Concept": {
+      "type": "object",
+      "properties": {
+        "coding": {
+          "type": "array",
+          "minItems": 0,
+          "items": {
+            "$ref": "#/definitions/Coding"
+          }
+        }
+      },
+      "required": [
+        "coding"
+      ]
+    },
+    "Coding": {
+      "type": "object",
+      "properties": {
+        "code": {
+          "type": "string"
+        },
+        "system": {
+          "type": "string",
+          "format": "uri"
+        },
+        "display": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-json-schema-export",
-  "version": "5.3.2",
+  "version": "6.0.0-beta.1",
   "description": "Exports SHR data elements from SHR models to JSON Schema",
   "author": "",
   "license": "Apache-2.0",
@@ -24,12 +24,12 @@
     "chai": "^3.5.0",
     "eslint": "^3.6.1",
     "mocha": "^3.2.0",
-    "shr-expand": "^5.5.2",
-    "shr-models": "^5.5.3",
-    "shr-test-helpers": "^5.2.2"
+    "shr-expand": "^6.0.0-beta.1",
+    "shr-models": "^6.0.0-beta.1",
+    "shr-test-helpers": "^6.0.0-beta.1"
   },
   "peerDependencies": {
     "bunyan": "^1.8.9",
-    "shr-models": "^5.5.3"
+    "shr-models": "^6.0.0-beta.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-json-schema-export",
-  "version": "6.0.0-beta.1",
+  "version": "6.0.0-beta.2",
   "description": "Exports SHR data elements from SHR models to JSON Schema",
   "author": "",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-json-schema-export",
-  "version": "6.0.0-beta.3",
+  "version": "6.0.0",
   "description": "Exports SHR data elements from SHR models to JSON Schema",
   "author": "",
   "license": "Apache-2.0",
@@ -24,12 +24,12 @@
     "chai": "^3.5.0",
     "eslint": "^3.6.1",
     "mocha": "^3.2.0",
-    "shr-expand": "^6.0.0-beta.2",
-    "shr-models": "^6.0.0-beta.2",
-    "shr-test-helpers": "^6.0.0-beta.2"
+    "shr-expand": "^6.0.0",
+    "shr-models": "^6.0.0",
+    "shr-test-helpers": "^6.0.0"
   },
   "peerDependencies": {
     "bunyan": "^1.8.9",
-    "shr-models": "^6.0.0-beta.2"
+    "shr-models": "^6.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "shr-json-schema-export",
-  "version": "6.0.0-beta.2",
+  "version": "6.0.0-beta.3",
   "description": "Exports SHR data elements from SHR models to JSON Schema",
   "author": "",
   "license": "Apache-2.0",
@@ -24,12 +24,12 @@
     "chai": "^3.5.0",
     "eslint": "^3.6.1",
     "mocha": "^3.2.0",
-    "shr-expand": "^6.0.0-beta.1",
-    "shr-models": "^6.0.0-beta.1",
-    "shr-test-helpers": "^6.0.0-beta.1"
+    "shr-expand": "^6.0.0-beta.2",
+    "shr-models": "^6.0.0-beta.2",
+    "shr-test-helpers": "^6.0.0-beta.2"
   },
   "peerDependencies": {
     "bunyan": "^1.8.9",
-    "shr-models": "^6.0.0-beta.1"
+    "shr-models": "^6.0.0-beta.2"
   }
 }

--- a/test/export_test.js
+++ b/test/export_test.js
@@ -65,7 +65,7 @@ function importFixture(name, ext='.schema.json') {
     }
     const valid = validator(instance);
     if (!valid) {
-      assert.fail(false, true, 'Errors validating instance: ' + ajv.errorsText(validator.errors));
+      assert.fail(false, true, `Errors validating instance in fixtures/instances/${name}.json: ` + ajv.errorsText(validator.errors));
     }
   }
   return fixture;

--- a/test/fixtures/AbstractAndPlainGroup.schema.json
+++ b/test/fixtures/AbstractAndPlainGroup.schema.json
@@ -3,53 +3,82 @@
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
     "title": "TODO: Figure out what the title should be.",
-    "type": "object",
-    "anyOf": [
-      { "$ref": "#/definitions/Simple" }
-    ],
     "definitions": {
       "AbstractAndPlainGroup": {
-        "description": "It is an abstract group of elements",
-        "concepts": [ { "code": "bar", "codeSystem": "http://foo.org", "displayText": "Foobar"}],
         "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
+          {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry"
+          },
           {
             "type": "object",
             "properties": {
-              "Simple": { "$ref": "#/definitions/Simple" },
-              "Plain": { "$ref": "#/definitions/Plain" }
+              "Simple": {
+                "$ref": "#/definitions/Simple"
+              },
+              "Plain": {
+                "$ref": "#/definitions/Plain"
+              }
             },
-            "required": ["Simple", "Plain"]
+            "required": [
+              "Simple",
+              "Plain"
+            ]
           }
+        ],
+        "concepts": [
+          {
+            "code": "bar",
+            "codeSystem": "http://foo.org",
+            "displayText": "Foobar"
+          }
+        ],
+        "description": "It is an abstract group of elements"
+      },
+      "Plain": {
+        "type": "object",
+        "properties": {
+          "Value": {
+            "type": "string"
+          },
+          "EntryType": {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+          }
+        },
+        "concepts": [
+          {
+            "code": "bar",
+            "codeSystem": "http://foo.org",
+            "displayText": "Foobar"
+          }
+        ],
+        "description": "It is not an entry element",
+        "required": [
+          "Value",
+          "EntryType"
         ]
       },
       "Simple": {
-        "description": "It is a simple element",
-        "concepts": [ { "code": "bar", "codeSystem": "http://foo.org", "displayText": "Foobar"}],
-        "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
-          {
-            "type": "object",
-            "properties": {
-              "Value": {
-                "type": "string"
-              }
-            },
-            "required": ["Value"]
-          }
-        ]
-      },
-      "Plain": {
-        "description": "It is not an entry element",
-        "concepts": [ { "code": "bar", "codeSystem": "http://foo.org", "displayText": "Foobar"}],
         "type": "object",
         "properties": {
-          "EntryType": { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType" },
           "Value": {
             "type": "string"
+          },
+          "EntryType": {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
           }
         },
-        "required": ["Value", "EntryType"]
+        "concepts": [
+          {
+            "code": "bar",
+            "codeSystem": "http://foo.org",
+            "displayText": "Foobar"
+          }
+        ],
+        "description": "It is a simple element",
+        "required": [
+          "Value",
+          "EntryType"
+        ]
       }
     }
   }

--- a/test/fixtures/AbstractAndPlainGroup.schema.json
+++ b/test/fixtures/AbstractAndPlainGroup.schema.json
@@ -1,4 +1,41 @@
 {
+  "https://standardhealthrecord.org/schema/cimpl/builtin": {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "https://standardhealthrecord.org/schema/cimpl/builtin",
+    "title": "CIMPL Builtin Schema",
+    "definitions": {
+      "Concept": {
+        "type": "object",
+        "properties": {
+          "coding": {
+            "type": "array",
+            "minItems": 0,
+            "items": {
+              "$ref": "#/definitions/Coding"
+            }
+          }
+        },
+        "required": [
+          "coding"
+        ]
+      },
+      "Coding": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "system": {
+            "type": "string",
+            "format": "uri"
+          },
+          "display": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
   "https://standardhealthrecord.org/test/shr/test": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
@@ -27,9 +64,13 @@
         ],
         "concepts": [
           {
-            "code": "bar",
-            "codeSystem": "http://foo.org",
-            "displayText": "Foobar"
+            "coding": [
+              {
+                "code": "bar",
+                "system": "http://foo.org",
+                "display": "Foobar"
+              }
+            ]
           }
         ],
         "description": "It is an abstract group of elements"
@@ -46,9 +87,13 @@
         },
         "concepts": [
           {
-            "code": "bar",
-            "codeSystem": "http://foo.org",
-            "displayText": "Foobar"
+            "coding": [
+              {
+                "code": "bar",
+                "system": "http://foo.org",
+                "display": "Foobar"
+              }
+            ]
           }
         ],
         "description": "It is not an entry element",
@@ -69,9 +114,13 @@
         },
         "concepts": [
           {
-            "code": "bar",
-            "codeSystem": "http://foo.org",
-            "displayText": "Foobar"
+            "coding": [
+              {
+                "code": "bar",
+                "system": "http://foo.org",
+                "display": "Foobar"
+              }
+            ]
           }
         ],
         "description": "It is a simple element",

--- a/test/fixtures/BooleanAndCodeConstraints.schema.json
+++ b/test/fixtures/BooleanAndCodeConstraints.schema.json
@@ -1,4 +1,41 @@
 {
+  "https://standardhealthrecord.org/schema/cimpl/builtin": {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "https://standardhealthrecord.org/schema/cimpl/builtin",
+    "title": "CIMPL Builtin Schema",
+    "definitions": {
+      "Concept": {
+        "type": "object",
+        "properties": {
+          "coding": {
+            "type": "array",
+            "minItems": 0,
+            "items": {
+              "$ref": "#/definitions/Coding"
+            }
+          }
+        },
+        "required": [
+          "coding"
+        ]
+      },
+      "Coding": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "system": {
+            "type": "string",
+            "format": "uri"
+          },
+          "display": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
   "https://standardhealthrecord.org/test/shr/test": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
@@ -47,8 +84,8 @@
                   "Value": {
                     "code": {
                       "code": "bar",
-                      "codeSystem": "http://foo.org",
-                      "displayText": "Foobar"
+                      "system": "http://foo.org",
+                      "display": "Foobar"
                     }
                   }
                 }
@@ -81,23 +118,7 @@
         "type": "object",
         "properties": {
           "Value": {
-            "type": "object",
-            "properties": {
-              "code": {
-                "type": "string"
-              },
-              "codeSystem": {
-                "type": "string",
-                "format": "uri"
-              },
-              "displayText": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "code",
-              "codeSystem"
-            ],
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/Concept",
             "valueSet": {
               "uri": "http://standardhealthrecord.org/test/vs/Coded",
               "strength": "REQUIRED"
@@ -167,14 +188,22 @@
         },
         "concepts": [
           {
-            "code": "bar",
-            "codeSystem": "http://foo.org",
-            "displayText": "Foobar"
+            "coding": [
+              {
+                "code": "bar",
+                "system": "http://foo.org",
+                "display": "Foobar"
+              }
+            ]
           },
           {
-            "code": "far",
-            "codeSystem": "http://boo.org",
-            "displayText": "Boofar"
+            "coding": [
+              {
+                "code": "far",
+                "system": "http://boo.org",
+                "display": "Boofar"
+              }
+            ]
           }
         ],
         "description": "It is a group of elements",
@@ -195,9 +224,13 @@
         },
         "concepts": [
           {
-            "code": "bar",
-            "codeSystem": "http://foo.org",
-            "displayText": "Foobar"
+            "coding": [
+              {
+                "code": "bar",
+                "system": "http://foo.org",
+                "display": "Foobar"
+              }
+            ]
           }
         ],
         "description": "It is a simple element",
@@ -231,9 +264,13 @@
         },
         "concepts": [
           {
-            "code": "bar",
-            "codeSystem": "http://foo.org",
-            "displayText": "Foobar"
+            "coding": [
+              {
+                "code": "bar",
+                "system": "http://foo.org",
+                "display": "Foobar"
+              }
+            ]
           }
         ],
         "description": "It is a simple element",

--- a/test/fixtures/BooleanAndCodeConstraints.schema.json
+++ b/test/fixtures/BooleanAndCodeConstraints.schema.json
@@ -3,183 +3,243 @@
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
     "title": "TODO: Figure out what the title should be.",
-    "type": "object",
-    "anyOf": [
-      { "$ref": "#/definitions/BooleanAndCodeConstraints" },
-      { "$ref": "#/definitions/Coded" },
-      { "$ref": "#/definitions/ElementValue" },
-      { "$ref": "#/definitions/ForeignElementValue" },
-      { "$ref": "#/definitions/Group" },
-      { "$ref": "#/definitions/Simple" }
-    ],
     "definitions": {
+      "Bool": {
+        "type": "object",
+        "properties": {
+          "Value": {
+            "type": "boolean"
+          },
+          "EntryType": {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+          }
+        },
+        "description": "A boolean element.",
+        "required": [
+          "EntryType"
+        ]
+      },
       "BooleanAndCodeConstraints": {
-        "description": "It has boolean and code constraints.",
         "allOf": [
-          { "$ref": "#/definitions/Group" },
+          {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry"
+          },
+          {
+            "$ref": "#/definitions/Group"
+          },
           {
             "type": "object",
             "properties": {
               "Value": {
                 "allOf": [
-                  { "type": "boolean" },
-                  { "enum": [ true ] }
-                ]
-              },
-              "Bool": {
-                "allOf": [
                   {
-                    "properties": {
-                      "Value": { "enum": [ false ] }
-                    }
+                    "type": "boolean"
                   },
-                  { "$ref": "#/definitions/Bool" }
+                  {
+                    "enum": [
+                      true
+                    ]
+                  }
                 ]
               },
               "Coded": {
                 "properties": {
                   "Value": {
-                    "code": { "code": "bar", "codeSystem": "http://foo.org", "displayText": "Foobar"}
+                    "code": {
+                      "code": "bar",
+                      "codeSystem": "http://foo.org",
+                      "displayText": "Foobar"
+                    }
                   }
                 }
+              },
+              "Bool": {
+                "allOf": [
+                  {
+                    "properties": {
+                      "Value": {
+                        "enum": [
+                          false
+                        ]
+                      }
+                    }
+                  },
+                  {
+                    "$ref": "#/definitions/Bool"
+                  }
+                ]
               }
             },
-            "required": ["Value"]
+            "required": [
+              "Value"
+            ]
           }
-        ]
-      },
-      "Bool": {
-        "type": "object",
-        "description": "A boolean element.",
-        "properties": {
-          "EntryType": {"$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType" },
-          "Value": {
-            "type": "boolean"
-          }
-        },
-        "required": ["EntryType"]
-      },
-      "Group": {
-        "description": "It is a group of elements",
-        "concepts": [
-          { "code": "bar", "codeSystem": "http://foo.org", "displayText": "Foobar"},
-          { "code": "far", "codeSystem": "http://boo.org", "displayText": "Boofar"}
         ],
-        "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
-          {
-            "type": "object",
-            "properties": {
-              "Simple": { "$ref": "#/definitions/Simple" },
-              "Coded": { "$ref": "#/definitions/Coded" },
-              "ElementValue": {
-                "type": "array",
-                "minItems": 0,
-                "items": {
-                  "$ref": "#/definitions/ElementValue"
-                }
-              }
-            },
-            "required": ["Simple"]
-          }
-        ]
+        "description": "It has boolean and code constraints."
       },
-      "Simple": {
-        "description": "It is a simple element",
-        "concepts": [ { "code": "bar", "codeSystem": "http://foo.org", "displayText": "Foobar"}],
-        "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
-          {
+      "Coded": {
+        "type": "object",
+        "properties": {
+          "Value": {
             "type": "object",
             "properties": {
-              "Value": {
+              "code": {
+                "type": "string"
+              },
+              "codeSystem": {
+                "type": "string",
+                "format": "uri"
+              },
+              "displayText": {
                 "type": "string"
               }
             },
-            "required": ["Value"]
+            "required": [
+              "code",
+              "codeSystem"
+            ],
+            "valueSet": {
+              "uri": "http://standardhealthrecord.org/test/vs/Coded",
+              "strength": "REQUIRED"
+            }
+          },
+          "EntryType": {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
           }
-        ]
-      },
-      "Coded": {
+        },
         "description": "It is a coded element",
-        "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
-          {
-            "type": "object",
-            "properties": {
-              "Value": {
-                "type": "object",
-                "properties": {
-                  "code": { "type": "string" },
-                  "codeSystem": { "type": "string", "format": "uri" },
-                  "displayText": { "type": "string" }
-                },
-                "required": [ "code", "codeSystem" ],
-                "valueSet": {
-                  "uri": "http://standardhealthrecord.org/test/vs/Coded",
-                  "strength": "REQUIRED"
-                }
-              }
-            },
-            "required": ["Value"]
-          }
-        ]
-      },
-      "ForeignElementValue": {
-        "description": "It is an element with a foreign element value",
-        "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
-          {
-            "type": "object",
-            "properties": {
-              "Value": {
-                "$ref": "https://standardhealthrecord.org/test/shr/other/test#/definitions/Simple"
-              }
-            },
-            "required": ["Value"]
-          }
+        "required": [
+          "Value",
+          "EntryType"
         ]
       },
       "ElementValue": {
-        "description": "It is an element with an element value",
-        "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
-          {
-            "type": "object",
-            "properties": {
-              "Value": {
-                "$ref": "#/definitions/Simple"
-              }
-            },
-            "required": ["Value"]
+        "type": "object",
+        "properties": {
+          "Value": {
+            "$ref": "#/definitions/Simple"
+          },
+          "EntryType": {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
           }
+        },
+        "description": "It is an element with an element value",
+        "required": [
+          "Value",
+          "EntryType"
+        ]
+      },
+      "ForeignElementValue": {
+        "type": "object",
+        "properties": {
+          "Value": {
+            "$ref": "https://standardhealthrecord.org/test/shr/other/test#/definitions/Simple"
+          },
+          "EntryType": {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+          }
+        },
+        "description": "It is an element with a foreign element value",
+        "required": [
+          "Value",
+          "EntryType"
+        ]
+      },
+      "Group": {
+        "type": "object",
+        "properties": {
+          "Simple": {
+            "$ref": "#/definitions/Simple"
+          },
+          "Coded": {
+            "$ref": "#/definitions/Coded"
+          },
+          "ElementValue": {
+            "type": "array",
+            "minItems": 0,
+            "items": {
+              "$ref": "#/definitions/ElementValue"
+            }
+          },
+          "EntryType": {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+          }
+        },
+        "concepts": [
+          {
+            "code": "bar",
+            "codeSystem": "http://foo.org",
+            "displayText": "Foobar"
+          },
+          {
+            "code": "far",
+            "codeSystem": "http://boo.org",
+            "displayText": "Boofar"
+          }
+        ],
+        "description": "It is a group of elements",
+        "required": [
+          "Simple",
+          "EntryType"
+        ]
+      },
+      "Simple": {
+        "type": "object",
+        "properties": {
+          "Value": {
+            "type": "string"
+          },
+          "EntryType": {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+          }
+        },
+        "concepts": [
+          {
+            "code": "bar",
+            "codeSystem": "http://foo.org",
+            "displayText": "Foobar"
+          }
+        ],
+        "description": "It is a simple element",
+        "required": [
+          "Value",
+          "EntryType"
         ]
       }
-    }
+    },
+    "type": "object",
+    "anyOf": [
+      {
+        "$ref": "#/definitions/BooleanAndCodeConstraints"
+      }
+    ]
   },
   "https://standardhealthrecord.org/test/shr/other/test": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/other/test",
     "title": "TODO: Figure out what the title should be.",
-    "type": "object",
-    "anyOf": [
-      { "$ref": "#/definitions/Simple" }
-    ],
     "definitions": {
       "Simple": {
-        "description": "It is a simple element",
-        "concepts": [ { "code": "bar", "codeSystem": "http://foo.org", "displayText": "Foobar"}],
-        "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
-          {
-            "type": "object",
-            "properties": {
-              "Value": {
-                "type": "string"
-              }
-            },
-            "required": ["Value"]
+        "type": "object",
+        "properties": {
+          "Value": {
+            "type": "string"
+          },
+          "EntryType": {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
           }
+        },
+        "concepts": [
+          {
+            "code": "bar",
+            "codeSystem": "http://foo.org",
+            "displayText": "Foobar"
+          }
+        ],
+        "description": "It is a simple element",
+        "required": [
+          "Value",
+          "EntryType"
         ]
       }
     }

--- a/test/fixtures/Choice.schema.json
+++ b/test/fixtures/Choice.schema.json
@@ -3,68 +3,98 @@
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
     "title": "TODO: Figure out what the title should be.",
-    "type": "object",
-    "anyOf": [
-      { "$ref": "#/definitions/Choice" },
-      { "$ref": "#/definitions/Coded" }
-    ],
     "definitions": {
       "Choice": {
-        "description": "It is an element with a choice",
         "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
+          {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry"
+          },
           {
             "type": "object",
             "properties": {
               "Value": {
                 "anyOf": [
-                  { "type": "string" },
+                  {
+                    "type": "string"
+                  },
                   {
                     "type": "object",
                     "properties": {
-                      "code": { "type": "string" },
-                      "codeSystem": { "type": "string", "format": "uri" },
-                      "displayText": { "type": "string" }
+                      "code": {
+                        "type": "string"
+                      },
+                      "codeSystem": {
+                        "type": "string",
+                        "format": "uri"
+                      },
+                      "displayText": {
+                        "type": "string"
+                      }
                     },
-                    "required": [ "code", "codeSystem" ],
+                    "required": [
+                      "code",
+                      "codeSystem"
+                    ],
                     "valueSet": {
                       "uri": "http://standardhealthrecord.org/test/vs/CodeChoice",
                       "strength": "REQUIRED"
                     }
                   },
-                  { "$ref": "#/definitions/Coded" }
+                  {
+                    "$ref": "#/definitions/Coded"
+                  }
                 ]
               }
             },
-            "required": ["Value"]
+            "required": [
+              "Value"
+            ]
           }
-        ]
+        ],
+        "description": "It is an element with a choice"
       },
       "Coded": {
-        "description": "It is a coded element",
-        "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
-          {
+        "type": "object",
+        "properties": {
+          "Value": {
             "type": "object",
             "properties": {
-              "Value": {
-                "type": "object",
-                "properties": {
-                  "code": { "type": "string" },
-                  "codeSystem": { "type": "string", "format": "uri" },
-                  "displayText": { "type": "string" }
-                },
-                "required": [ "code", "codeSystem" ],
-                "valueSet": {
-                  "uri": "http://standardhealthrecord.org/test/vs/Coded",
-                  "strength": "REQUIRED"
-                }
+              "code": {
+                "type": "string"
+              },
+              "codeSystem": {
+                "type": "string",
+                "format": "uri"
+              },
+              "displayText": {
+                "type": "string"
               }
             },
-            "required": ["Value"]
+            "required": [
+              "code",
+              "codeSystem"
+            ],
+            "valueSet": {
+              "uri": "http://standardhealthrecord.org/test/vs/Coded",
+              "strength": "REQUIRED"
+            }
+          },
+          "EntryType": {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
           }
+        },
+        "description": "It is a coded element",
+        "required": [
+          "Value",
+          "EntryType"
         ]
       }
-    }
+    },
+    "type": "object",
+    "anyOf": [
+      {
+        "$ref": "#/definitions/Choice"
+      }
+    ]
   }
 }

--- a/test/fixtures/Choice.schema.json
+++ b/test/fixtures/Choice.schema.json
@@ -1,4 +1,41 @@
 {
+  "https://standardhealthrecord.org/schema/cimpl/builtin": {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "https://standardhealthrecord.org/schema/cimpl/builtin",
+    "title": "CIMPL Builtin Schema",
+    "definitions": {
+      "Concept": {
+        "type": "object",
+        "properties": {
+          "coding": {
+            "type": "array",
+            "minItems": 0,
+            "items": {
+              "$ref": "#/definitions/Coding"
+            }
+          }
+        },
+        "required": [
+          "coding"
+        ]
+      },
+      "Coding": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "system": {
+            "type": "string",
+            "format": "uri"
+          },
+          "display": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
   "https://standardhealthrecord.org/test/shr/test": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
@@ -18,23 +55,7 @@
                     "type": "string"
                   },
                   {
-                    "type": "object",
-                    "properties": {
-                      "code": {
-                        "type": "string"
-                      },
-                      "codeSystem": {
-                        "type": "string",
-                        "format": "uri"
-                      },
-                      "displayText": {
-                        "type": "string"
-                      }
-                    },
-                    "required": [
-                      "code",
-                      "codeSystem"
-                    ],
+                    "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/Concept",
                     "valueSet": {
                       "uri": "http://standardhealthrecord.org/test/vs/CodeChoice",
                       "strength": "REQUIRED"
@@ -57,23 +78,7 @@
         "type": "object",
         "properties": {
           "Value": {
-            "type": "object",
-            "properties": {
-              "code": {
-                "type": "string"
-              },
-              "codeSystem": {
-                "type": "string",
-                "format": "uri"
-              },
-              "displayText": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "code",
-              "codeSystem"
-            ],
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/Concept",
             "valueSet": {
               "uri": "http://standardhealthrecord.org/test/vs/Coded",
               "strength": "REQUIRED"

--- a/test/fixtures/ChoiceOfChoice.schema.json
+++ b/test/fixtures/ChoiceOfChoice.schema.json
@@ -1,37 +1,71 @@
 {
+  "https://standardhealthrecord.org/schema/cimpl/builtin": {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "https://standardhealthrecord.org/schema/cimpl/builtin",
+    "title": "CIMPL Builtin Schema",
+    "definitions": {
+      "Concept": {
+        "type": "object",
+        "properties": {
+          "coding": {
+            "type": "array",
+            "minItems": 0,
+            "items": {
+              "$ref": "#/definitions/Coding"
+            }
+          }
+        },
+        "required": [
+          "coding"
+        ]
+      },
+      "Coding": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "system": {
+            "type": "string",
+            "format": "uri"
+          },
+          "display": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
   "https://standardhealthrecord.org/test/shr/test": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
     "title": "TODO: Figure out what the title should be.",
-    "type": "object",
-    "anyOf": [
-      { "$ref": "#/definitions/ChoiceOfChoice" }
-    ],
     "definitions": {
       "ChoiceOfChoice": {
-        "description": "It is an element with a choice containing a choice",
         "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
+          {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry"
+          },
           {
             "type": "object",
             "properties": {
               "Value": {
                 "anyOf": [
-                  { "type": "string" },
+                  {
+                    "type": "string"
+                  },
                   {
                     "anyOf": [
-                      { "type": "integer" },
-                      { "type": "number" }
+                      {
+                        "type": "integer"
+                      },
+                      {
+                        "type": "number"
+                      }
                     ]
                   },
                   {
-                    "type": "object",
-                    "properties": {
-                      "code": { "type": "string" },
-                      "codeSystem": { "type": "string", "format": "uri" },
-                      "displayText": { "type": "string" }
-                    },
-                    "required": [ "code", "codeSystem" ],
+                    "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/Concept",
                     "valueSet": {
                       "uri": "http://standardhealthrecord.org/test/vs/CodeChoice",
                       "strength": "REQUIRED"
@@ -40,10 +74,19 @@
                 ]
               }
             },
-            "required": ["Value"]
+            "required": [
+              "Value"
+            ]
           }
-        ]
+        ],
+        "description": "It is an element with a choice containing a choice"
       }
-    }
+    },
+    "type": "object",
+    "anyOf": [
+      {
+        "$ref": "#/definitions/ChoiceOfChoice"
+      }
+    ]
   }
 }

--- a/test/fixtures/ChoiceValueSetConstraint.schema.json
+++ b/test/fixtures/ChoiceValueSetConstraint.schema.json
@@ -1,4 +1,41 @@
 {
+  "https://standardhealthrecord.org/schema/cimpl/builtin": {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "https://standardhealthrecord.org/schema/cimpl/builtin",
+    "title": "CIMPL Builtin Schema",
+    "definitions": {
+      "Concept": {
+        "type": "object",
+        "properties": {
+          "coding": {
+            "type": "array",
+            "minItems": 0,
+            "items": {
+              "$ref": "#/definitions/Coding"
+            }
+          }
+        },
+        "required": [
+          "coding"
+        ]
+      },
+      "Coding": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "system": {
+            "type": "string",
+            "format": "uri"
+          },
+          "display": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
   "https://standardhealthrecord.org/test/shr/test": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
@@ -38,23 +75,7 @@
         "type": "object",
         "properties": {
           "Value": {
-            "type": "object",
-            "properties": {
-              "code": {
-                "type": "string"
-              },
-              "codeSystem": {
-                "type": "string",
-                "format": "uri"
-              },
-              "displayText": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "code",
-              "codeSystem"
-            ],
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/Concept",
             "valueSet": {
               "uri": "http://standardhealthrecord.org/test/vs/Coded",
               "strength": "REQUIRED"
@@ -79,23 +100,7 @@
                 "$ref": "#/definitions/Coded"
               },
               {
-                "type": "object",
-                "properties": {
-                  "code": {
-                    "type": "string"
-                  },
-                  "codeSystem": {
-                    "type": "string",
-                    "format": "uri"
-                  },
-                  "displayText": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "code",
-                  "codeSystem"
-                ]
+                "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/Concept"
               }
             ]
           },

--- a/test/fixtures/ChoiceValueSetConstraint.schema.json
+++ b/test/fixtures/ChoiceValueSetConstraint.schema.json
@@ -3,17 +3,12 @@
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
     "title": "TODO: Figure out what the title should be.",
-    "type": "object",
-    "anyOf": [
-      { "$ref": "#/definitions/ChoiceValueSetConstraint" },
-      { "$ref": "#/definitions/Coded" },
-      { "$ref": "#/definitions/CodedChoice" }
-    ],
     "definitions": {
       "ChoiceValueSetConstraint": {
-        "description": "It has valueset constraints on a choice field.",
         "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
+          {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry"
+          },
           {
             "type": "object",
             "properties": {
@@ -29,63 +24,96 @@
                       }
                     }
                   },
-                  { "$ref": "#/definitions/CodedChoice" }
-                ]
-              }
-            }
-          }
-        ]
-      },
-      "CodedChoice": {
-        "description": "An element with a choice of code fields.",
-        "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
-          {
-            "type": "object",
-            "properties": {
-              "Value": {
-                "anyOf": [
-                  { "$ref": "#/definitions/Coded" },
                   {
-                    "type": "object",
-                    "properties": {
-                      "code": { "type": "string" },
-                      "codeSystem": { "type": "string", "format": "uri" },
-                      "displayText": { "type": "string" }
-                    },
-                    "required": [ "code", "codeSystem" ]
+                    "$ref": "#/definitions/CodedChoice"
                   }
                 ]
               }
             }
           }
-        ]
+        ],
+        "description": "It has valueset constraints on a choice field."
       },
       "Coded": {
-        "description": "It is a coded element",
-        "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
-          {
+        "type": "object",
+        "properties": {
+          "Value": {
             "type": "object",
             "properties": {
-              "Value": {
-                "type": "object",
-                "properties": {
-                  "code": { "type": "string" },
-                  "codeSystem": { "type": "string", "format": "uri" },
-                  "displayText": { "type": "string" }
-                },
-                "required": [ "code", "codeSystem" ],
-                "valueSet": {
-                  "uri": "http://standardhealthrecord.org/test/vs/Coded",
-                  "strength": "REQUIRED"
-                }
+              "code": {
+                "type": "string"
+              },
+              "codeSystem": {
+                "type": "string",
+                "format": "uri"
+              },
+              "displayText": {
+                "type": "string"
               }
             },
-            "required": ["Value"]
+            "required": [
+              "code",
+              "codeSystem"
+            ],
+            "valueSet": {
+              "uri": "http://standardhealthrecord.org/test/vs/Coded",
+              "strength": "REQUIRED"
+            }
+          },
+          "EntryType": {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
           }
+        },
+        "description": "It is a coded element",
+        "required": [
+          "Value",
+          "EntryType"
+        ]
+      },
+      "CodedChoice": {
+        "type": "object",
+        "properties": {
+          "Value": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/Coded"
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "code": {
+                    "type": "string"
+                  },
+                  "codeSystem": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "displayText": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "code",
+                  "codeSystem"
+                ]
+              }
+            ]
+          },
+          "EntryType": {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+          }
+        },
+        "description": "An element with a choice of code fields.",
+        "required": [
+          "EntryType"
         ]
       }
-    }
+    },
+    "type": "object",
+    "anyOf": [
+      {
+        "$ref": "#/definitions/ChoiceValueSetConstraint"
+      }
+    ]
   }
 }

--- a/test/fixtures/Coded.schema.json
+++ b/test/fixtures/Coded.schema.json
@@ -1,38 +1,75 @@
 {
+  "https://standardhealthrecord.org/schema/cimpl/builtin": {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "https://standardhealthrecord.org/schema/cimpl/builtin",
+    "title": "CIMPL Builtin Schema",
+    "definitions": {
+      "Concept": {
+        "type": "object",
+        "properties": {
+          "coding": {
+            "type": "array",
+            "minItems": 0,
+            "items": {
+              "$ref": "#/definitions/Coding"
+            }
+          }
+        },
+        "required": [
+          "coding"
+        ]
+      },
+      "Coding": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "system": {
+            "type": "string",
+            "format": "uri"
+          },
+          "display": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
   "https://standardhealthrecord.org/test/shr/test": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
     "title": "TODO: Figure out what the title should be.",
-    "type": "object",
-    "anyOf": [
-      { "$ref": "#/definitions/Coded" }
-    ],
     "definitions": {
       "Coded": {
-        "description": "It is a coded element",
         "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
+          {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry"
+          },
           {
             "type": "object",
             "properties": {
               "Value": {
-                "type": "object",
-                "properties": {
-                  "code": { "type": "string" },
-                  "codeSystem": { "type": "string", "format": "uri" },
-                  "displayText": { "type": "string" }
-                },
-                "required": [ "code", "codeSystem" ],
+                "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/Concept",
                 "valueSet": {
                   "uri": "http://standardhealthrecord.org/test/vs/Coded",
                   "strength": "REQUIRED"
                 }
               }
             },
-            "required": ["Value"]
+            "required": [
+              "Value"
+            ]
           }
-        ]
+        ],
+        "description": "It is a coded element"
       }
-    }
+    },
+    "type": "object",
+    "anyOf": [
+      {
+        "$ref": "#/definitions/Coded"
+      }
+    ]
   }
 }

--- a/test/fixtures/ElementValue.schema.json
+++ b/test/fixtures/ElementValue.schema.json
@@ -3,16 +3,12 @@
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
     "title": "TODO: Figure out what the title should be.",
-    "type": "object",
-    "anyOf": [
-      { "$ref": "#/definitions/ElementValue" },
-      { "$ref": "#/definitions/Simple" }
-    ],
     "definitions": {
       "ElementValue": {
-        "description": "It is an element with an element value",
         "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
+          {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry"
+          },
           {
             "type": "object",
             "properties": {
@@ -20,26 +16,42 @@
                 "$ref": "#/definitions/Simple"
               }
             },
-            "required": ["Value"]
+            "required": [
+              "Value"
+            ]
           }
-        ]
+        ],
+        "description": "It is an element with an element value"
       },
       "Simple": {
-        "description": "It is a simple element",
-        "concepts": [ { "code": "bar", "codeSystem": "http://foo.org", "displayText": "Foobar"}],
-        "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
-          {
-            "type": "object",
-            "properties": {
-              "Value": {
-                "type": "string"
-              }
-            },
-            "required": ["Value"]
+        "type": "object",
+        "properties": {
+          "Value": {
+            "type": "string"
+          },
+          "EntryType": {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
           }
+        },
+        "concepts": [
+          {
+            "code": "bar",
+            "codeSystem": "http://foo.org",
+            "displayText": "Foobar"
+          }
+        ],
+        "description": "It is a simple element",
+        "required": [
+          "Value",
+          "EntryType"
         ]
       }
-    }
+    },
+    "type": "object",
+    "anyOf": [
+      {
+        "$ref": "#/definitions/ElementValue"
+      }
+    ]
   }
 }

--- a/test/fixtures/ElementValue.schema.json
+++ b/test/fixtures/ElementValue.schema.json
@@ -1,4 +1,41 @@
 {
+  "https://standardhealthrecord.org/schema/cimpl/builtin": {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "https://standardhealthrecord.org/schema/cimpl/builtin",
+    "title": "CIMPL Builtin Schema",
+    "definitions": {
+      "Concept": {
+        "type": "object",
+        "properties": {
+          "coding": {
+            "type": "array",
+            "minItems": 0,
+            "items": {
+              "$ref": "#/definitions/Coding"
+            }
+          }
+        },
+        "required": [
+          "coding"
+        ]
+      },
+      "Coding": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "system": {
+            "type": "string",
+            "format": "uri"
+          },
+          "display": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
   "https://standardhealthrecord.org/test/shr/test": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
@@ -35,9 +72,13 @@
         },
         "concepts": [
           {
-            "code": "bar",
-            "codeSystem": "http://foo.org",
-            "displayText": "Foobar"
+            "coding": [
+              {
+                "code": "bar",
+                "system": "http://foo.org",
+                "display": "Foobar"
+              }
+            ]
           }
         ],
         "description": "It is a simple element",

--- a/test/fixtures/ForeignElementValue.schema.json
+++ b/test/fixtures/ForeignElementValue.schema.json
@@ -1,4 +1,41 @@
 {
+  "https://standardhealthrecord.org/schema/cimpl/builtin": {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "https://standardhealthrecord.org/schema/cimpl/builtin",
+    "title": "CIMPL Builtin Schema",
+    "definitions": {
+      "Concept": {
+        "type": "object",
+        "properties": {
+          "coding": {
+            "type": "array",
+            "minItems": 0,
+            "items": {
+              "$ref": "#/definitions/Coding"
+            }
+          }
+        },
+        "required": [
+          "coding"
+        ]
+      },
+      "Coding": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "system": {
+            "type": "string",
+            "format": "uri"
+          },
+          "display": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
   "https://standardhealthrecord.org/test/shr/test": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
@@ -48,9 +85,13 @@
         },
         "concepts": [
           {
-            "code": "bar",
-            "codeSystem": "http://foo.org",
-            "displayText": "Foobar"
+            "coding": [
+              {
+                "code": "bar",
+                "system": "http://foo.org",
+                "display": "Foobar"
+              }
+            ]
           }
         ],
         "description": "It is a simple element",

--- a/test/fixtures/ForeignElementValue.schema.json
+++ b/test/fixtures/ForeignElementValue.schema.json
@@ -3,15 +3,12 @@
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
     "title": "TODO: Figure out what the title should be.",
-    "type": "object",
-    "anyOf": [
-      { "$ref": "#/definitions/ForeignElementValue" }
-    ],
     "definitions": {
       "ForeignElementValue": {
-        "description": "It is an element with a foreign element value",
         "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
+          {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry"
+          },
           {
             "type": "object",
             "properties": {
@@ -19,35 +16,47 @@
                 "$ref": "https://standardhealthrecord.org/test/shr/other/test#/definitions/Simple"
               }
             },
-            "required": ["Value"]
+            "required": [
+              "Value"
+            ]
           }
-        ]
+        ],
+        "description": "It is an element with a foreign element value"
       }
-    }
+    },
+    "type": "object",
+    "anyOf": [
+      {
+        "$ref": "#/definitions/ForeignElementValue"
+      }
+    ]
   },
   "https://standardhealthrecord.org/test/shr/other/test": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/other/test",
     "title": "TODO: Figure out what the title should be.",
-    "type": "object",
-    "anyOf": [
-      { "$ref": "#/definitions/Simple" }
-    ],
     "definitions": {
       "Simple": {
-        "description": "It is a simple element",
-        "concepts": [ { "code": "bar", "codeSystem": "http://foo.org", "displayText": "Foobar"}],
-        "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
-          {
-            "type": "object",
-            "properties": {
-              "Value": {
-                "type": "string"
-              }
-            },
-            "required": ["Value"]
+        "type": "object",
+        "properties": {
+          "Value": {
+            "type": "string"
+          },
+          "EntryType": {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
           }
+        },
+        "concepts": [
+          {
+            "code": "bar",
+            "codeSystem": "http://foo.org",
+            "displayText": "Foobar"
+          }
+        ],
+        "description": "It is a simple element",
+        "required": [
+          "Value",
+          "EntryType"
         ]
       }
     }

--- a/test/fixtures/ForeignSimple.schema.json
+++ b/test/fixtures/ForeignSimple.schema.json
@@ -1,18 +1,51 @@
 {
+  "https://standardhealthrecord.org/schema/cimpl/builtin": {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "https://standardhealthrecord.org/schema/cimpl/builtin",
+    "title": "CIMPL Builtin Schema",
+    "definitions": {
+      "Concept": {
+        "type": "object",
+        "properties": {
+          "coding": {
+            "type": "array",
+            "minItems": 0,
+            "items": {
+              "$ref": "#/definitions/Coding"
+            }
+          }
+        },
+        "required": [
+          "coding"
+        ]
+      },
+      "Coding": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "system": {
+            "type": "string",
+            "format": "uri"
+          },
+          "display": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
   "https://standardhealthrecord.org/test/shr/other/test": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/other/test",
     "title": "TODO: Figure out what the title should be.",
-    "type": "object",
-    "anyOf": [
-      { "$ref": "#/definitions/Simple" }
-    ],
     "definitions": {
       "Simple": {
-        "description": "It is a simple element",
-        "concepts": [ { "code": "bar", "codeSystem": "http://foo.org", "displayText": "Foobar"}],
         "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
+          {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry"
+          },
           {
             "type": "object",
             "properties": {
@@ -20,10 +53,30 @@
                 "type": "string"
               }
             },
-            "required": ["Value"]
+            "required": [
+              "Value"
+            ]
           }
-        ]
+        ],
+        "concepts": [
+          {
+            "coding": [
+              {
+                "code": "bar",
+                "system": "http://foo.org",
+                "display": "Foobar"
+              }
+            ]
+          }
+        ],
+        "description": "It is a simple element"
       }
-    }
+    },
+    "type": "object",
+    "anyOf": [
+      {
+        "$ref": "#/definitions/Simple"
+      }
+    ]
   }
 }

--- a/test/fixtures/Group.schema.json
+++ b/test/fixtures/Group.schema.json
@@ -1,4 +1,41 @@
 {
+  "https://standardhealthrecord.org/schema/cimpl/builtin": {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "https://standardhealthrecord.org/schema/cimpl/builtin",
+    "title": "CIMPL Builtin Schema",
+    "definitions": {
+      "Concept": {
+        "type": "object",
+        "properties": {
+          "coding": {
+            "type": "array",
+            "minItems": 0,
+            "items": {
+              "$ref": "#/definitions/Coding"
+            }
+          }
+        },
+        "required": [
+          "coding"
+        ]
+      },
+      "Coding": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "system": {
+            "type": "string",
+            "format": "uri"
+          },
+          "display": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
   "https://standardhealthrecord.org/test/shr/test": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
@@ -8,23 +45,7 @@
         "type": "object",
         "properties": {
           "Value": {
-            "type": "object",
-            "properties": {
-              "code": {
-                "type": "string"
-              },
-              "codeSystem": {
-                "type": "string",
-                "format": "uri"
-              },
-              "displayText": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "code",
-              "codeSystem"
-            ],
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/Concept",
             "valueSet": {
               "uri": "http://standardhealthrecord.org/test/vs/Coded",
               "strength": "REQUIRED"
@@ -101,14 +122,22 @@
         ],
         "concepts": [
           {
-            "code": "bar",
-            "codeSystem": "http://foo.org",
-            "displayText": "Foobar"
+            "coding": [
+              {
+                "code": "bar",
+                "system": "http://foo.org",
+                "display": "Foobar"
+              }
+            ]
           },
           {
-            "code": "far",
-            "codeSystem": "http://boo.org",
-            "displayText": "Boofar"
+            "coding": [
+              {
+                "code": "far",
+                "system": "http://boo.org",
+                "display": "Boofar"
+              }
+            ]
           }
         ],
         "description": "It is a group of elements"
@@ -125,9 +154,13 @@
         },
         "concepts": [
           {
-            "code": "bar",
-            "codeSystem": "http://foo.org",
-            "displayText": "Foobar"
+            "coding": [
+              {
+                "code": "bar",
+                "system": "http://foo.org",
+                "display": "Foobar"
+              }
+            ]
           }
         ],
         "description": "It is a simple element",
@@ -161,9 +194,13 @@
         },
         "concepts": [
           {
-            "code": "bar",
-            "codeSystem": "http://foo.org",
-            "displayText": "Foobar"
+            "coding": [
+              {
+                "code": "bar",
+                "system": "http://foo.org",
+                "display": "Foobar"
+              }
+            ]
           }
         ],
         "description": "It is a simple element",

--- a/test/fixtures/Group.schema.json
+++ b/test/fixtures/Group.schema.json
@@ -3,28 +3,89 @@
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
     "title": "TODO: Figure out what the title should be.",
-    "type": "object",
-    "anyOf": [
-      { "$ref": "#/definitions/Coded" },
-      { "$ref": "#/definitions/ElementValue" },
-      { "$ref": "#/definitions/ForeignElementValue" },
-      { "$ref": "#/definitions/Group" },
-      { "$ref": "#/definitions/Simple" }
-    ],
     "definitions": {
+      "Coded": {
+        "type": "object",
+        "properties": {
+          "Value": {
+            "type": "object",
+            "properties": {
+              "code": {
+                "type": "string"
+              },
+              "codeSystem": {
+                "type": "string",
+                "format": "uri"
+              },
+              "displayText": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "code",
+              "codeSystem"
+            ],
+            "valueSet": {
+              "uri": "http://standardhealthrecord.org/test/vs/Coded",
+              "strength": "REQUIRED"
+            }
+          },
+          "EntryType": {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+          }
+        },
+        "description": "It is a coded element",
+        "required": [
+          "Value",
+          "EntryType"
+        ]
+      },
+      "ElementValue": {
+        "type": "object",
+        "properties": {
+          "Value": {
+            "$ref": "#/definitions/Simple"
+          },
+          "EntryType": {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+          }
+        },
+        "description": "It is an element with an element value",
+        "required": [
+          "Value",
+          "EntryType"
+        ]
+      },
+      "ForeignElementValue": {
+        "type": "object",
+        "properties": {
+          "Value": {
+            "$ref": "https://standardhealthrecord.org/test/shr/other/test#/definitions/Simple"
+          },
+          "EntryType": {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+          }
+        },
+        "description": "It is an element with a foreign element value",
+        "required": [
+          "Value",
+          "EntryType"
+        ]
+      },
       "Group": {
-        "description": "It is a group of elements",
-        "concepts": [
-          { "code": "bar", "codeSystem": "http://foo.org", "displayText": "Foobar"},
-          { "code": "far", "codeSystem": "http://boo.org", "displayText": "Boofar"}
-        ],
         "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
+          {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry"
+          },
           {
             "type": "object",
             "properties": {
-              "Simple": { "$ref": "#/definitions/Simple" },
-              "Coded": { "$ref": "#/definitions/Coded" },
+              "Simple": {
+                "$ref": "#/definitions/Simple"
+              },
+              "Coded": {
+                "$ref": "#/definitions/Coded"
+              },
               "ElementValue": {
                 "type": "array",
                 "minItems": 0,
@@ -33,106 +94,82 @@
                 }
               }
             },
-            "required": ["Simple"]
+            "required": [
+              "Simple"
+            ]
           }
-        ]
+        ],
+        "concepts": [
+          {
+            "code": "bar",
+            "codeSystem": "http://foo.org",
+            "displayText": "Foobar"
+          },
+          {
+            "code": "far",
+            "codeSystem": "http://boo.org",
+            "displayText": "Boofar"
+          }
+        ],
+        "description": "It is a group of elements"
       },
       "Simple": {
+        "type": "object",
+        "properties": {
+          "Value": {
+            "type": "string"
+          },
+          "EntryType": {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+          }
+        },
+        "concepts": [
+          {
+            "code": "bar",
+            "codeSystem": "http://foo.org",
+            "displayText": "Foobar"
+          }
+        ],
         "description": "It is a simple element",
-        "concepts": [ { "code": "bar", "codeSystem": "http://foo.org", "displayText": "Foobar"}],
-        "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
-          {
-            "type": "object",
-            "properties": {
-              "Value": {
-                "type": "string"
-              }
-            },
-            "required": ["Value"]
-          }
-        ]
-      },
-      "Coded": {
-        "description": "It is a coded element",
-        "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
-          {
-            "type": "object",
-            "properties": {
-              "Value": {
-                "type": "object",
-                "properties": {
-                  "code": { "type": "string" },
-                  "codeSystem": { "type": "string", "format": "uri" },
-                  "displayText": { "type": "string" }
-                },
-                "required": [ "code", "codeSystem" ],
-                "valueSet": {
-                  "uri": "http://standardhealthrecord.org/test/vs/Coded",
-                  "strength": "REQUIRED"
-                }
-              }
-            },
-            "required": ["Value"]
-          }
-        ]
-      },
-      "ForeignElementValue": {
-        "description": "It is an element with a foreign element value",
-        "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
-          {
-            "type": "object",
-            "properties": {
-              "Value": {
-                "$ref": "https://standardhealthrecord.org/test/shr/other/test#/definitions/Simple"
-              }
-            },
-            "required": ["Value"]
-          }
-        ]
-      },
-      "ElementValue": {
-        "description": "It is an element with an element value",
-        "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
-          {
-            "type": "object",
-            "properties": {
-              "Value": {
-                "$ref": "#/definitions/Simple"
-              }
-            },
-            "required": ["Value"]
-          }
+        "required": [
+          "Value",
+          "EntryType"
         ]
       }
-    }
+    },
+    "type": "object",
+    "anyOf": [
+      {
+        "$ref": "#/definitions/Group"
+      }
+    ]
   },
   "https://standardhealthrecord.org/test/shr/other/test": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/other/test",
     "title": "TODO: Figure out what the title should be.",
-    "type": "object",
-    "anyOf": [
-      { "$ref": "#/definitions/Simple" }
-    ],
     "definitions": {
       "Simple": {
-        "description": "It is a simple element",
-        "concepts": [ { "code": "bar", "codeSystem": "http://foo.org", "displayText": "Foobar"}],
-        "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
-          {
-            "type": "object",
-            "properties": {
-              "Value": {
-                "type": "string"
-              }
-            },
-            "required": ["Value"]
+        "type": "object",
+        "properties": {
+          "Value": {
+            "type": "string"
+          },
+          "EntryType": {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
           }
+        },
+        "concepts": [
+          {
+            "code": "bar",
+            "codeSystem": "http://foo.org",
+            "displayText": "Foobar"
+          }
+        ],
+        "description": "It is a simple element",
+        "required": [
+          "Value",
+          "EntryType"
         ]
       }
     }

--- a/test/fixtures/GroupDerivative.schema.json
+++ b/test/fixtures/GroupDerivative.schema.json
@@ -3,152 +3,192 @@
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
     "title": "TODO: Figure out what the title should be.",
-    "type": "object",
-    "anyOf": [
-      { "$ref": "#/definitions/Coded" },
-      { "$ref": "#/definitions/ElementValue" },
-      { "$ref": "#/definitions/ForeignElementValue" },
-      { "$ref": "#/definitions/Group" },
-      { "$ref": "#/definitions/GroupDerivative" },
-      { "$ref": "#/definitions/Simple" }
-    ],
     "definitions": {
-      "GroupDerivative": {
-        "description": "It is a derivative of a group of elements",
-        "allOf": [
-          { "$ref": "#/definitions/Group" },
-          {
-            "type": "object",
-            "properties": {
-              "Value": {
-                "type": "string"
-              }
-            },
-            "required": ["Value"]
-          }
-        ]
-      },
-      "Group": {
-        "description": "It is a group of elements",
-        "concepts": [
-          { "code": "bar", "codeSystem": "http://foo.org", "displayText": "Foobar"},
-          { "code": "far", "codeSystem": "http://boo.org", "displayText": "Boofar"}
-        ],
-        "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
-          {
-            "type": "object",
-            "properties": {
-              "Simple": { "$ref": "#/definitions/Simple" },
-              "Coded": { "$ref": "#/definitions/Coded" },
-              "ElementValue": {
-                "type": "array",
-                "minItems": 0,
-                "items": {
-                  "$ref": "#/definitions/ElementValue"
-                }
-              }
-            },
-            "required": ["Simple"]
-          }
-        ]
-      },
-      "Simple": {
-        "description": "It is a simple element",
-        "concepts": [ { "code": "bar", "codeSystem": "http://foo.org", "displayText": "Foobar"}],
-        "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
-          {
-            "type": "object",
-            "properties": {
-              "Value": {
-                "type": "string"
-              }
-            },
-            "required": ["Value"]
-          }
-        ]
-      },
       "Coded": {
+        "type": "object",
+        "properties": {
+          "Value": {
+            "type": "object",
+            "properties": {
+              "code": {
+                "type": "string"
+              },
+              "codeSystem": {
+                "type": "string",
+                "format": "uri"
+              },
+              "displayText": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "code",
+              "codeSystem"
+            ],
+            "valueSet": {
+              "uri": "http://standardhealthrecord.org/test/vs/Coded",
+              "strength": "REQUIRED"
+            }
+          },
+          "EntryType": {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+          }
+        },
         "description": "It is a coded element",
-        "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
-          {
-            "type": "object",
-            "properties": {
-              "Value": {
-                "type": "object",
-                "properties": {
-                  "code": { "type": "string" },
-                  "codeSystem": { "type": "string", "format": "uri" },
-                  "displayText": { "type": "string" }
-                },
-                "required": [ "code", "codeSystem" ],
-                "valueSet": {
-                  "uri": "http://standardhealthrecord.org/test/vs/Coded",
-                  "strength": "REQUIRED"
-                }
-              }
-            },
-            "required": ["Value"]
-          }
-        ]
-      },
-      "ForeignElementValue": {
-        "description": "It is an element with a foreign element value",
-        "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
-          {
-            "type": "object",
-            "properties": {
-              "Value": {
-                "$ref": "https://standardhealthrecord.org/test/shr/other/test#/definitions/Simple"
-              }
-            },
-            "required": ["Value"]
-          }
+        "required": [
+          "Value",
+          "EntryType"
         ]
       },
       "ElementValue": {
+        "type": "object",
+        "properties": {
+          "Value": {
+            "$ref": "#/definitions/Simple"
+          },
+          "EntryType": {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+          }
+        },
         "description": "It is an element with an element value",
+        "required": [
+          "Value",
+          "EntryType"
+        ]
+      },
+      "ForeignElementValue": {
+        "type": "object",
+        "properties": {
+          "Value": {
+            "$ref": "https://standardhealthrecord.org/test/shr/other/test#/definitions/Simple"
+          },
+          "EntryType": {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+          }
+        },
+        "description": "It is an element with a foreign element value",
+        "required": [
+          "Value",
+          "EntryType"
+        ]
+      },
+      "Group": {
+        "type": "object",
+        "properties": {
+          "Simple": {
+            "$ref": "#/definitions/Simple"
+          },
+          "Coded": {
+            "$ref": "#/definitions/Coded"
+          },
+          "ElementValue": {
+            "type": "array",
+            "minItems": 0,
+            "items": {
+              "$ref": "#/definitions/ElementValue"
+            }
+          },
+          "EntryType": {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+          }
+        },
+        "concepts": [
+          {
+            "code": "bar",
+            "codeSystem": "http://foo.org",
+            "displayText": "Foobar"
+          },
+          {
+            "code": "far",
+            "codeSystem": "http://boo.org",
+            "displayText": "Boofar"
+          }
+        ],
+        "description": "It is a group of elements",
+        "required": [
+          "Simple",
+          "EntryType"
+        ]
+      },
+      "GroupDerivative": {
         "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
+          {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry"
+          },
+          {
+            "$ref": "#/definitions/Group"
+          },
           {
             "type": "object",
             "properties": {
               "Value": {
-                "$ref": "#/definitions/Simple"
+                "type": "string"
               }
             },
-            "required": ["Value"]
+            "required": [
+              "Value"
+            ]
           }
+        ],
+        "description": "It is a derivative of a group of elements"
+      },
+      "Simple": {
+        "type": "object",
+        "properties": {
+          "Value": {
+            "type": "string"
+          },
+          "EntryType": {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+          }
+        },
+        "concepts": [
+          {
+            "code": "bar",
+            "codeSystem": "http://foo.org",
+            "displayText": "Foobar"
+          }
+        ],
+        "description": "It is a simple element",
+        "required": [
+          "Value",
+          "EntryType"
         ]
       }
-    }
+    },
+    "type": "object",
+    "anyOf": [
+      {
+        "$ref": "#/definitions/GroupDerivative"
+      }
+    ]
   },
   "https://standardhealthrecord.org/test/shr/other/test": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/other/test",
     "title": "TODO: Figure out what the title should be.",
-    "type": "object",
-    "anyOf": [
-      { "$ref": "#/definitions/Simple" }
-    ],
     "definitions": {
       "Simple": {
-        "description": "It is a simple element",
-        "concepts": [ { "code": "bar", "codeSystem": "http://foo.org", "displayText": "Foobar"}],
-        "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
-          {
-            "type": "object",
-            "properties": {
-              "Value": {
-                "type": "string"
-              }
-            },
-            "required": ["Value"]
+        "type": "object",
+        "properties": {
+          "Value": {
+            "type": "string"
+          },
+          "EntryType": {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
           }
+        },
+        "concepts": [
+          {
+            "code": "bar",
+            "codeSystem": "http://foo.org",
+            "displayText": "Foobar"
+          }
+        ],
+        "description": "It is a simple element",
+        "required": [
+          "Value",
+          "EntryType"
         ]
       }
     }

--- a/test/fixtures/GroupDerivative.schema.json
+++ b/test/fixtures/GroupDerivative.schema.json
@@ -1,4 +1,41 @@
 {
+  "https://standardhealthrecord.org/schema/cimpl/builtin": {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "https://standardhealthrecord.org/schema/cimpl/builtin",
+    "title": "CIMPL Builtin Schema",
+    "definitions": {
+      "Concept": {
+        "type": "object",
+        "properties": {
+          "coding": {
+            "type": "array",
+            "minItems": 0,
+            "items": {
+              "$ref": "#/definitions/Coding"
+            }
+          }
+        },
+        "required": [
+          "coding"
+        ]
+      },
+      "Coding": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "system": {
+            "type": "string",
+            "format": "uri"
+          },
+          "display": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
   "https://standardhealthrecord.org/test/shr/test": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
@@ -8,23 +45,7 @@
         "type": "object",
         "properties": {
           "Value": {
-            "type": "object",
-            "properties": {
-              "code": {
-                "type": "string"
-              },
-              "codeSystem": {
-                "type": "string",
-                "format": "uri"
-              },
-              "displayText": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "code",
-              "codeSystem"
-            ],
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/Concept",
             "valueSet": {
               "uri": "http://standardhealthrecord.org/test/vs/Coded",
               "strength": "REQUIRED"
@@ -94,14 +115,22 @@
         },
         "concepts": [
           {
-            "code": "bar",
-            "codeSystem": "http://foo.org",
-            "displayText": "Foobar"
+            "coding": [
+              {
+                "code": "bar",
+                "system": "http://foo.org",
+                "display": "Foobar"
+              }
+            ]
           },
           {
-            "code": "far",
-            "codeSystem": "http://boo.org",
-            "displayText": "Boofar"
+            "coding": [
+              {
+                "code": "far",
+                "system": "http://boo.org",
+                "display": "Boofar"
+              }
+            ]
           }
         ],
         "description": "It is a group of elements",
@@ -144,9 +173,13 @@
         },
         "concepts": [
           {
-            "code": "bar",
-            "codeSystem": "http://foo.org",
-            "displayText": "Foobar"
+            "coding": [
+              {
+                "code": "bar",
+                "system": "http://foo.org",
+                "display": "Foobar"
+              }
+            ]
           }
         ],
         "description": "It is a simple element",
@@ -180,9 +213,13 @@
         },
         "concepts": [
           {
-            "code": "bar",
-            "codeSystem": "http://foo.org",
-            "displayText": "Foobar"
+            "coding": [
+              {
+                "code": "bar",
+                "system": "http://foo.org",
+                "display": "Foobar"
+              }
+            ]
           }
         ],
         "description": "It is a simple element",

--- a/test/fixtures/GroupPathClash.schema.json
+++ b/test/fixtures/GroupPathClash.schema.json
@@ -3,63 +3,76 @@
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
     "title": "TODO: Figure out what the title should be.",
-    "type": "object",
-    "anyOf": [
-      { "$ref": "#/definitions/GroupPathClash" },
-      { "$ref": "#/definitions/Simple" }
-    ],
     "definitions": {
       "GroupPathClash": {
-        "description": "It is a group of elements with clashing names",
         "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
+          {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry"
+          },
           {
             "type": "object",
             "properties": {}
           }
-        ]
+        ],
+        "description": "It is a group of elements with clashing names"
       },
       "Simple": {
-        "description": "It is a simple element",
-        "concepts": [ { "code": "bar", "codeSystem": "http://foo.org", "displayText": "Foobar"}],
-        "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
-          {
-            "type": "object",
-            "properties": {
-              "Value": {
-                "type": "string"
-              }
-            },
-            "required": ["Value"]
+        "type": "object",
+        "properties": {
+          "Value": {
+            "type": "string"
+          },
+          "EntryType": {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
           }
+        },
+        "concepts": [
+          {
+            "code": "bar",
+            "codeSystem": "http://foo.org",
+            "displayText": "Foobar"
+          }
+        ],
+        "description": "It is a simple element",
+        "required": [
+          "Value",
+          "EntryType"
         ]
       }
-    }
+    },
+    "type": "object",
+    "anyOf": [
+      {
+        "$ref": "#/definitions/GroupPathClash"
+      }
+    ]
   },
   "https://standardhealthrecord.org/test/shr/other/test": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/other/test",
     "title": "TODO: Figure out what the title should be.",
-    "type": "object",
-    "anyOf": [
-      { "$ref": "#/definitions/Simple" }
-    ],
     "definitions": {
       "Simple": {
-        "description": "It is a simple element",
-        "concepts": [ { "code": "bar", "codeSystem": "http://foo.org", "displayText": "Foobar"}],
-        "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
-          {
-            "type": "object",
-            "properties": {
-              "Value": {
-                "type": "string"
-              }
-            },
-            "required": ["Value"]
+        "type": "object",
+        "properties": {
+          "Value": {
+            "type": "string"
+          },
+          "EntryType": {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
           }
+        },
+        "concepts": [
+          {
+            "code": "bar",
+            "codeSystem": "http://foo.org",
+            "displayText": "Foobar"
+          }
+        ],
+        "description": "It is a simple element",
+        "required": [
+          "Value",
+          "EntryType"
         ]
       }
     }

--- a/test/fixtures/GroupPathClash.schema.json
+++ b/test/fixtures/GroupPathClash.schema.json
@@ -1,4 +1,41 @@
 {
+  "https://standardhealthrecord.org/schema/cimpl/builtin": {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "https://standardhealthrecord.org/schema/cimpl/builtin",
+    "title": "CIMPL Builtin Schema",
+    "definitions": {
+      "Concept": {
+        "type": "object",
+        "properties": {
+          "coding": {
+            "type": "array",
+            "minItems": 0,
+            "items": {
+              "$ref": "#/definitions/Coding"
+            }
+          }
+        },
+        "required": [
+          "coding"
+        ]
+      },
+      "Coding": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "system": {
+            "type": "string",
+            "format": "uri"
+          },
+          "display": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
   "https://standardhealthrecord.org/test/shr/test": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
@@ -28,9 +65,13 @@
         },
         "concepts": [
           {
-            "code": "bar",
-            "codeSystem": "http://foo.org",
-            "displayText": "Foobar"
+            "coding": [
+              {
+                "code": "bar",
+                "system": "http://foo.org",
+                "display": "Foobar"
+              }
+            ]
           }
         ],
         "description": "It is a simple element",
@@ -64,9 +105,13 @@
         },
         "concepts": [
           {
-            "code": "bar",
-            "codeSystem": "http://foo.org",
-            "displayText": "Foobar"
+            "coding": [
+              {
+                "code": "bar",
+                "system": "http://foo.org",
+                "display": "Foobar"
+              }
+            ]
           }
         ],
         "description": "It is a simple element",

--- a/test/fixtures/GroupPathClash_errors.json
+++ b/test/fixtures/GroupPathClash_errors.json
@@ -1,0 +1,5 @@
+[
+  {
+    "msg": "ERROR: clashing property names: shr.test.Simple and shr.other.test.Simple ERROR_CODE: 12038"
+  }
+]

--- a/test/fixtures/GroupWithChoiceOfChoice.schema.json
+++ b/test/fixtures/GroupWithChoiceOfChoice.schema.json
@@ -1,4 +1,41 @@
 {
+  "https://standardhealthrecord.org/schema/cimpl/builtin": {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "https://standardhealthrecord.org/schema/cimpl/builtin",
+    "title": "CIMPL Builtin Schema",
+    "definitions": {
+      "Concept": {
+        "type": "object",
+        "properties": {
+          "coding": {
+            "type": "array",
+            "minItems": 0,
+            "items": {
+              "$ref": "#/definitions/Coding"
+            }
+          }
+        },
+        "required": [
+          "coding"
+        ]
+      },
+      "Coding": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "system": {
+            "type": "string",
+            "format": "uri"
+          },
+          "display": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
   "https://standardhealthrecord.org/test/shr/test": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
@@ -8,23 +45,7 @@
         "type": "object",
         "properties": {
           "Value": {
-            "type": "object",
-            "properties": {
-              "code": {
-                "type": "string"
-              },
-              "codeSystem": {
-                "type": "string",
-                "format": "uri"
-              },
-              "displayText": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "code",
-              "codeSystem"
-            ],
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/Concept",
             "valueSet": {
               "uri": "http://standardhealthrecord.org/test/vs/Coded",
               "strength": "REQUIRED"
@@ -128,9 +149,13 @@
         },
         "concepts": [
           {
-            "code": "bar",
-            "codeSystem": "http://foo.org",
-            "displayText": "Foobar"
+            "coding": [
+              {
+                "code": "bar",
+                "system": "http://foo.org",
+                "display": "Foobar"
+              }
+            ]
           }
         ],
         "description": "It is a simple element",
@@ -164,9 +189,13 @@
         },
         "concepts": [
           {
-            "code": "bar",
-            "codeSystem": "http://foo.org",
-            "displayText": "Foobar"
+            "coding": [
+              {
+                "code": "bar",
+                "system": "http://foo.org",
+                "display": "Foobar"
+              }
+            ]
           }
         ],
         "description": "It is a simple element",

--- a/test/fixtures/GroupWithChoiceOfChoice.schema.json
+++ b/test/fixtures/GroupWithChoiceOfChoice.schema.json
@@ -3,19 +3,80 @@
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
     "title": "TODO: Figure out what the title should be.",
-    "type": "object",
-    "anyOf": [
-      { "$ref": "#/definitions/Coded" },
-      { "$ref": "#/definitions/ElementValue" },
-      { "$ref": "#/definitions/ForeignElementValue" },
-      { "$ref": "#/definitions/GroupWithChoiceOfChoice" },
-      { "$ref": "#/definitions/Simple" }
-    ],
     "definitions": {
+      "Coded": {
+        "type": "object",
+        "properties": {
+          "Value": {
+            "type": "object",
+            "properties": {
+              "code": {
+                "type": "string"
+              },
+              "codeSystem": {
+                "type": "string",
+                "format": "uri"
+              },
+              "displayText": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "code",
+              "codeSystem"
+            ],
+            "valueSet": {
+              "uri": "http://standardhealthrecord.org/test/vs/Coded",
+              "strength": "REQUIRED"
+            }
+          },
+          "EntryType": {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+          }
+        },
+        "description": "It is a coded element",
+        "required": [
+          "Value",
+          "EntryType"
+        ]
+      },
+      "ElementValue": {
+        "type": "object",
+        "properties": {
+          "Value": {
+            "$ref": "#/definitions/Simple"
+          },
+          "EntryType": {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+          }
+        },
+        "description": "It is an element with an element value",
+        "required": [
+          "Value",
+          "EntryType"
+        ]
+      },
+      "ForeignElementValue": {
+        "type": "object",
+        "properties": {
+          "Value": {
+            "$ref": "https://standardhealthrecord.org/test/shr/other/test#/definitions/Simple"
+          },
+          "EntryType": {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+          }
+        },
+        "description": "It is an element with a foreign element value",
+        "required": [
+          "Value",
+          "EntryType"
+        ]
+      },
       "GroupWithChoiceOfChoice": {
-        "description": "It is a group of elements with a choice containing a choice",
         "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
+          {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry"
+          },
           {
             "type": "object",
             "properties": {
@@ -25,119 +86,93 @@
                 "maxItems": 2,
                 "items": {
                   "anyOf": [
-                    { "$ref": "https://standardhealthrecord.org/test/shr/other/test#/definitions/Simple" },
+                    {
+                      "$ref": "https://standardhealthrecord.org/test/shr/other/test#/definitions/Simple"
+                    },
                     {
                       "anyOf": [
-                        { "$ref": "#/definitions/ForeignElementValue" },
-                        { "$ref": "#/definitions/ElementValue" }
+                        {
+                          "$ref": "#/definitions/ForeignElementValue"
+                        },
+                        {
+                          "$ref": "#/definitions/ElementValue"
+                        }
                       ]
                     }
                   ]
                 }
               },
-              "Simple": { "$ref": "#/definitions/Simple" },
-              "Coded": { "$ref": "#/definitions/Coded" }
+              "Simple": {
+                "$ref": "#/definitions/Simple"
+              },
+              "Coded": {
+                "$ref": "#/definitions/Coded"
+              }
             },
-            "required": [ "Simple" ]
+            "required": [
+              "Simple"
+            ]
           }
-        ]
+        ],
+        "description": "It is a group of elements with a choice containing a choice"
       },
       "Simple": {
+        "type": "object",
+        "properties": {
+          "Value": {
+            "type": "string"
+          },
+          "EntryType": {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+          }
+        },
+        "concepts": [
+          {
+            "code": "bar",
+            "codeSystem": "http://foo.org",
+            "displayText": "Foobar"
+          }
+        ],
         "description": "It is a simple element",
-        "concepts": [ { "code": "bar", "codeSystem": "http://foo.org", "displayText": "Foobar"}],
-        "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
-          {
-            "type": "object",
-            "properties": {
-              "Value": {
-                "type": "string"
-              }
-            },
-            "required": ["Value"]
-          }
-        ]
-      },
-      "Coded": {
-        "description": "It is a coded element",
-        "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
-          {
-            "type": "object",
-            "properties": {
-              "Value": {
-                "type": "object",
-                "properties": {
-                  "code": { "type": "string" },
-                  "codeSystem": { "type": "string", "format": "uri" },
-                  "displayText": { "type": "string" }
-                },
-                "required": [ "code", "codeSystem" ],
-                "valueSet": {
-                  "uri": "http://standardhealthrecord.org/test/vs/Coded",
-                  "strength": "REQUIRED"
-                }
-              }
-            },
-            "required": ["Value"]
-          }
-        ]
-      },
-      "ForeignElementValue": {
-        "description": "It is an element with a foreign element value",
-        "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
-          {
-            "type": "object",
-            "properties": {
-              "Value": {
-                "$ref": "https://standardhealthrecord.org/test/shr/other/test#/definitions/Simple"
-              }
-            },
-            "required": ["Value"]
-          }
-        ]
-      },
-      "ElementValue": {
-        "description": "It is an element with an element value",
-        "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
-          {
-            "type": "object",
-            "properties": {
-              "Value": {
-                "$ref": "#/definitions/Simple"
-              }
-            },
-            "required": ["Value"]
-          }
+        "required": [
+          "Value",
+          "EntryType"
         ]
       }
-    }
+    },
+    "type": "object",
+    "anyOf": [
+      {
+        "$ref": "#/definitions/GroupWithChoiceOfChoice"
+      }
+    ]
   },
   "https://standardhealthrecord.org/test/shr/other/test": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/other/test",
     "title": "TODO: Figure out what the title should be.",
-    "type": "object",
-    "anyOf": [
-      { "$ref": "#/definitions/Simple" }
-    ],
     "definitions": {
       "Simple": {
-        "description": "It is a simple element",
-        "concepts": [ { "code": "bar", "codeSystem": "http://foo.org", "displayText": "Foobar"}],
-        "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
-          {
-            "type": "object",
-            "properties": {
-              "Value": {
-                "type": "string"
-              }
-            },
-            "required": ["Value"]
+        "type": "object",
+        "properties": {
+          "Value": {
+            "type": "string"
+          },
+          "EntryType": {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
           }
+        },
+        "concepts": [
+          {
+            "code": "bar",
+            "codeSystem": "http://foo.org",
+            "displayText": "Foobar"
+          }
+        ],
+        "description": "It is a simple element",
+        "required": [
+          "Value",
+          "EntryType"
         ]
       }
     }

--- a/test/fixtures/IncludesCodeConstraints.schema.json
+++ b/test/fixtures/IncludesCodeConstraints.schema.json
@@ -16,23 +16,33 @@
                 "type": "array",
                 "minItems": 0,
                 "items": {
-                  "allOf": [
+                  "type": "object",
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "codeSystem": {
+                      "type": "string",
+                      "format": "uri"
+                    },
+                    "displayText": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "code",
+                    "codeSystem"
+                  ],
+                  "includesCodes": [
                     {
-                      "includesCodes": [
-                        {
-                          "code": "bar",
-                          "codeSystem": "http://foo.org",
-                          "displayText": "Foobar"
-                        },
-                        {
-                          "code": "far",
-                          "codeSystem": "http://boo.org",
-                          "displayText": "Boofar"
-                        }
-                      ]
+                      "code": "bar",
+                      "codeSystem": "http://foo.org",
+                      "displayText": "Foobar"
                     },
                     {
-                      "$ref": "https://standardhealthrecord.org/test/shr/core#/definitions/CodeableConcept"
+                      "code": "far",
+                      "codeSystem": "http://boo.org",
+                      "displayText": "Boofar"
                     }
                   ]
                 }
@@ -49,118 +59,5 @@
         "$ref": "#/definitions/IncludesCodesList"
       }
     ]
-  },
-  "https://standardhealthrecord.org/test/shr/core": {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "https://standardhealthrecord.org/test/shr/core",
-    "title": "TODO: Figure out what the title should be.",
-    "definitions": {
-      "CodeableConcept": {
-        "type": "object",
-        "properties": {
-          "Coding": {
-            "type": "array",
-            "minItems": 0,
-            "items": {
-              "$ref": "#/definitions/Coding"
-            }
-          },
-          "DisplayText": {
-            "$ref": "#/definitions/DisplayText"
-          },
-          "EntryType": {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
-          }
-        },
-        "required": [
-          "EntryType"
-        ]
-      },
-      "CodeSystem": {
-        "type": "object",
-        "properties": {
-          "Value": {
-            "type": "string",
-            "format": "uri"
-          },
-          "EntryType": {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
-          }
-        },
-        "required": [
-          "Value",
-          "EntryType"
-        ]
-      },
-      "CodeSystemVersion": {
-        "type": "object",
-        "properties": {
-          "Value": {
-            "type": "string"
-          },
-          "EntryType": {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
-          }
-        },
-        "required": [
-          "Value",
-          "EntryType"
-        ]
-      },
-      "Coding": {
-        "type": "object",
-        "properties": {
-          "Value": {
-            "type": "object",
-            "properties": {
-              "code": {
-                "type": "string"
-              },
-              "codeSystem": {
-                "type": "string",
-                "format": "uri"
-              },
-              "displayText": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "code",
-              "codeSystem"
-            ]
-          },
-          "CodeSystem": {
-            "$ref": "#/definitions/CodeSystem"
-          },
-          "CodeSystemVersion": {
-            "$ref": "#/definitions/CodeSystemVersion"
-          },
-          "DisplayText": {
-            "$ref": "#/definitions/DisplayText"
-          },
-          "EntryType": {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
-          }
-        },
-        "required": [
-          "EntryType"
-        ]
-      },
-      "DisplayText": {
-        "type": "object",
-        "properties": {
-          "Value": {
-            "type": "string"
-          },
-          "EntryType": {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
-          }
-        },
-        "required": [
-          "Value",
-          "EntryType"
-        ]
-      }
-    }
   }
 }

--- a/test/fixtures/IncludesCodeConstraints.schema.json
+++ b/test/fixtures/IncludesCodeConstraints.schema.json
@@ -1,4 +1,41 @@
 {
+  "https://standardhealthrecord.org/schema/cimpl/builtin": {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "https://standardhealthrecord.org/schema/cimpl/builtin",
+    "title": "CIMPL Builtin Schema",
+    "definitions": {
+      "Concept": {
+        "type": "object",
+        "properties": {
+          "coding": {
+            "type": "array",
+            "minItems": 0,
+            "items": {
+              "$ref": "#/definitions/Coding"
+            }
+          }
+        },
+        "required": [
+          "coding"
+        ]
+      },
+      "Coding": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "system": {
+            "type": "string",
+            "format": "uri"
+          },
+          "display": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
   "https://standardhealthrecord.org/test/shr/test": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
@@ -16,33 +53,17 @@
                 "type": "array",
                 "minItems": 0,
                 "items": {
-                  "type": "object",
-                  "properties": {
-                    "code": {
-                      "type": "string"
-                    },
-                    "codeSystem": {
-                      "type": "string",
-                      "format": "uri"
-                    },
-                    "displayText": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "code",
-                    "codeSystem"
-                  ],
+                  "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/Concept",
                   "includesCodes": [
                     {
                       "code": "bar",
-                      "codeSystem": "http://foo.org",
-                      "displayText": "Foobar"
+                      "system": "http://foo.org",
+                      "display": "Foobar"
                     },
                     {
                       "code": "far",
-                      "codeSystem": "http://boo.org",
-                      "displayText": "Boofar"
+                      "system": "http://boo.org",
+                      "display": "Boofar"
                     }
                   ]
                 }

--- a/test/fixtures/IncludesTypeConstraints.schema.json
+++ b/test/fixtures/IncludesTypeConstraints.schema.json
@@ -1,4 +1,41 @@
 {
+  "https://standardhealthrecord.org/schema/cimpl/builtin": {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "https://standardhealthrecord.org/schema/cimpl/builtin",
+    "title": "CIMPL Builtin Schema",
+    "definitions": {
+      "Concept": {
+        "type": "object",
+        "properties": {
+          "coding": {
+            "type": "array",
+            "minItems": 0,
+            "items": {
+              "$ref": "#/definitions/Coding"
+            }
+          }
+        },
+        "required": [
+          "coding"
+        ]
+      },
+      "Coding": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "system": {
+            "type": "string",
+            "format": "uri"
+          },
+          "display": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
   "https://standardhealthrecord.org/test/shr/test": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
@@ -63,9 +100,13 @@
         },
         "concepts": [
           {
-            "code": "bar",
-            "codeSystem": "http://foo.org",
-            "displayText": "Foobar"
+            "coding": [
+              {
+                "code": "bar",
+                "system": "http://foo.org",
+                "display": "Foobar"
+              }
+            ]
           }
         ],
         "description": "It is a simple element",

--- a/test/fixtures/IncludesTypeConstraints.schema.json
+++ b/test/fixtures/IncludesTypeConstraints.schema.json
@@ -3,36 +3,36 @@
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
     "title": "TODO: Figure out what the title should be.",
-    "type": "object",
-    "anyOf": [
-      { "$ref": "#/definitions/IncludesTypesList" },
-      { "$ref": "#/definitions/Simple" },
-      { "$ref": "#/definitions/SimpleChild" },
-      { "$ref": "#/definitions/SimpleChild2" }
-    ],
     "definitions": {
       "IncludesTypesList": {
-        "description": "An entry with a includes types constraints.",
         "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
+          {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry"
+          },
           {
             "type": "object",
             "properties": {
               "Value": {
                 "type": "array",
                 "minItems": 0,
-                "maxItems": 3,
                 "items": {
                   "allOf": [
-                    { "$ref": "#/definitions/Simple" },
+                    {
+                      "$ref": "#/definitions/Simple"
+                    },
                     {
                       "anyOf": [
-                        { "$ref": "#/definitions/SimpleChild" },
-                        { "$ref": "#/definitions/SimpleChild2" }
+                        {
+                          "$ref": "#/definitions/SimpleChild"
+                        },
+                        {
+                          "$ref": "#/definitions/SimpleChild2"
+                        }
                       ]
                     }
                   ]
                 },
+                "maxItems": 3,
                 "includesTypes": [
                   {
                     "items": "http://standardhealthrecord.org/spec/shr/test/SimpleChild",
@@ -48,44 +48,62 @@
               }
             }
           }
-        ]
+        ],
+        "description": "An entry with a includes types constraints."
       },
       "Simple": {
-        "description": "It is a simple element",
-        "concepts": [ { "code": "bar", "codeSystem": "http://foo.org", "displayText": "Foobar"}],
-        "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
-          {
-            "type": "object",
-            "properties": {
-              "Value": {
-                "type": "string"
-              }
-            },
-            "required": ["Value"]
+        "type": "object",
+        "properties": {
+          "Value": {
+            "type": "string"
+          },
+          "EntryType": {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
           }
+        },
+        "concepts": [
+          {
+            "code": "bar",
+            "codeSystem": "http://foo.org",
+            "displayText": "Foobar"
+          }
+        ],
+        "description": "It is a simple element",
+        "required": [
+          "Value",
+          "EntryType"
         ]
       },
       "SimpleChild": {
-        "description": "A derivative of the simple type.",
         "allOf": [
-          { "$ref": "#/definitions/Simple" },
+          {
+            "$ref": "#/definitions/Simple"
+          },
           {
             "type": "object",
             "properties": {}
           }
-        ]
+        ],
+        "description": "A derivative of the simple type."
       },
       "SimpleChild2": {
-        "description": "A derivative of the simple type.",
         "allOf": [
-          { "$ref": "#/definitions/Simple" },
+          {
+            "$ref": "#/definitions/Simple"
+          },
           {
             "type": "object",
             "properties": {}
           }
-        ]
+        ],
+        "description": "A derivative of the simple type."
       }
-    }
+    },
+    "type": "object",
+    "anyOf": [
+      {
+        "$ref": "#/definitions/IncludesTypesList"
+      }
+    ]
   }
 }

--- a/test/fixtures/NestedCardConstraint.schema.json
+++ b/test/fixtures/NestedCardConstraint.schema.json
@@ -1,55 +1,110 @@
 {
+  "https://standardhealthrecord.org/schema/cimpl/builtin": {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "https://standardhealthrecord.org/schema/cimpl/builtin",
+    "title": "CIMPL Builtin Schema",
+    "definitions": {
+      "Concept": {
+        "type": "object",
+        "properties": {
+          "coding": {
+            "type": "array",
+            "minItems": 0,
+            "items": {
+              "$ref": "#/definitions/Coding"
+            }
+          }
+        },
+        "required": [
+          "coding"
+        ]
+      },
+      "Coding": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "system": {
+            "type": "string",
+            "format": "uri"
+          },
+          "display": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
   "https://standardhealthrecord.org/test/shr/test": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
     "title": "TODO: Figure out what the title should be.",
-    "type": "object",
-    "anyOf": [
-      { "$ref": "#/definitions/NestedCardConstraint" }
-    ],
     "definitions": {
       "NestedCardConstraint": {
-        "description": "It has a field with a nested card constraint.",
         "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
+          {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry"
+          },
           {
             "type": "object",
             "properties": {
               "OptionalField": {
                 "allOf": [
-                  { "$ref": "#/definitions/OptionalField" },
                   {
-                    "required": ["OptionalValue"]
+                    "$ref": "#/definitions/OptionalField"
+                  },
+                  {
+                    "required": [
+                      "OptionalValue"
+                    ]
                   }
                 ]
               }
             },
-            "required": ["OptionalField"]
+            "required": [
+              "OptionalField"
+            ]
           }
-        ]
+        ],
+        "description": "It has a field with a nested card constraint."
       },
       "OptionalField": {
-        "description": "An element with an optional field.",
         "type": "object",
         "properties": {
-          "EntryType": { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType" },
           "OptionalValue": {
             "$ref": "#/definitions/OptionalValue"
+          },
+          "EntryType": {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
           }
         },
-        "required": ["EntryType"]
+        "description": "An element with an optional field.",
+        "required": [
+          "EntryType"
+        ]
       },
       "OptionalValue": {
-        "description": "An element with an optional value.",
         "type": "object",
         "properties": {
-          "EntryType": { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType" },
           "Value": {
             "type": "string"
+          },
+          "EntryType": {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
           }
         },
-        "required": ["EntryType"]
+        "description": "An element with an optional value.",
+        "required": [
+          "EntryType"
+        ]
       }
-    }
+    },
+    "type": "object",
+    "anyOf": [
+      {
+        "$ref": "#/definitions/NestedCardConstraint"
+      }
+    ]
   }
 }

--- a/test/fixtures/NestedListCardConstraints.schema.json
+++ b/test/fixtures/NestedListCardConstraints.schema.json
@@ -1,17 +1,67 @@
 {
+  "https://standardhealthrecord.org/schema/cimpl/builtin": {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "https://standardhealthrecord.org/schema/cimpl/builtin",
+    "title": "CIMPL Builtin Schema",
+    "definitions": {
+      "Concept": {
+        "type": "object",
+        "properties": {
+          "coding": {
+            "type": "array",
+            "minItems": 0,
+            "items": {
+              "$ref": "#/definitions/Coding"
+            }
+          }
+        },
+        "required": [
+          "coding"
+        ]
+      },
+      "Coding": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "system": {
+            "type": "string",
+            "format": "uri"
+          },
+          "display": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
   "https://standardhealthrecord.org/test/shr/test": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
     "title": "TODO: Figure out what the title should be.",
-    "type": "object",
-    "anyOf": [
-      { "$ref": "#/definitions/NestedListCardConstraints" }
-    ],
     "definitions": {
+      "ListField": {
+        "type": "object",
+        "properties": {
+          "OptionalList": {
+            "$ref": "#/definitions/OptionalList"
+          },
+          "EntryType": {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+          }
+        },
+        "description": "An element with a list field.",
+        "required": [
+          "OptionalList",
+          "EntryType"
+        ]
+      },
       "NestedListCardConstraints": {
-        "description": "It has a field with a nested card constraint on a list.",
         "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
+          {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry"
+          },
           {
             "type": "object",
             "properties": {
@@ -30,45 +80,53 @@
                               }
                             }
                           },
-                          { "required": ["Value"] }
+                          {
+                            "required": [
+                              "Value"
+                            ]
+                          }
                         ]
                       }
                     }
                   },
-                  { "$ref": "#/definitions/ListField" }
+                  {
+                    "$ref": "#/definitions/ListField"
+                  }
                 ]
               }
             },
-            "required": ["ListField"]
+            "required": [
+              "ListField"
+            ]
           }
-        ]
-      },
-      "ListField": {
-        "description": "An element with a list field.",
-        "type": "object",
-        "properties": {
-          "EntryType": { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType" },
-          "OptionalList": {
-            "$ref": "#/definitions/OptionalList"
-          }
-        },
-        "required": ["OptionalList", "EntryType"]
+        ],
+        "description": "It has a field with a nested card constraint on a list."
       },
       "OptionalList": {
-        "description": "An element with an optional list.",
         "type": "object",
         "properties": {
-          "EntryType": { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType" },
           "Value": {
             "type": "array",
             "minItems": 0,
             "items": {
               "type": "string"
             }
+          },
+          "EntryType": {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
           }
         },
-        "required": ["EntryType"]
+        "description": "An element with an optional list.",
+        "required": [
+          "EntryType"
+        ]
       }
-    }
+    },
+    "type": "object",
+    "anyOf": [
+      {
+        "$ref": "#/definitions/NestedListCardConstraints"
+      }
+    ]
   }
 }

--- a/test/fixtures/NestedValueSetConstraints.schema.json
+++ b/test/fixtures/NestedValueSetConstraints.schema.json
@@ -3,20 +3,121 @@
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
     "title": "TODO: Figure out what the title should be.",
-    "type": "object",
-    "anyOf": [
-      { "$ref": "#/definitions/Coded" },
-      { "$ref": "#/definitions/ElementValue" },
-      { "$ref": "#/definitions/ForeignElementValue" },
-      { "$ref": "#/definitions/Group" },
-      { "$ref": "#/definitions/NestedValueSetConstraints" },
-      { "$ref": "#/definitions/Simple" }
-    ],
     "definitions": {
+      "Coded": {
+        "type": "object",
+        "properties": {
+          "Value": {
+            "type": "object",
+            "properties": {
+              "code": {
+                "type": "string"
+              },
+              "codeSystem": {
+                "type": "string",
+                "format": "uri"
+              },
+              "displayText": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "code",
+              "codeSystem"
+            ],
+            "valueSet": {
+              "uri": "http://standardhealthrecord.org/test/vs/Coded",
+              "strength": "REQUIRED"
+            }
+          },
+          "EntryType": {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+          }
+        },
+        "description": "It is a coded element",
+        "required": [
+          "Value",
+          "EntryType"
+        ]
+      },
+      "ElementValue": {
+        "type": "object",
+        "properties": {
+          "Value": {
+            "$ref": "#/definitions/Simple"
+          },
+          "EntryType": {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+          }
+        },
+        "description": "It is an element with an element value",
+        "required": [
+          "Value",
+          "EntryType"
+        ]
+      },
+      "ForeignElementValue": {
+        "type": "object",
+        "properties": {
+          "Value": {
+            "$ref": "https://standardhealthrecord.org/test/shr/other/test#/definitions/Simple"
+          },
+          "EntryType": {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+          }
+        },
+        "description": "It is an element with a foreign element value",
+        "required": [
+          "Value",
+          "EntryType"
+        ]
+      },
+      "Group": {
+        "type": "object",
+        "properties": {
+          "Simple": {
+            "$ref": "#/definitions/Simple"
+          },
+          "Coded": {
+            "$ref": "#/definitions/Coded"
+          },
+          "ElementValue": {
+            "type": "array",
+            "minItems": 0,
+            "items": {
+              "$ref": "#/definitions/ElementValue"
+            }
+          },
+          "EntryType": {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+          }
+        },
+        "concepts": [
+          {
+            "code": "bar",
+            "codeSystem": "http://foo.org",
+            "displayText": "Foobar"
+          },
+          {
+            "code": "far",
+            "codeSystem": "http://boo.org",
+            "displayText": "Boofar"
+          }
+        ],
+        "description": "It is a group of elements",
+        "required": [
+          "Simple",
+          "EntryType"
+        ]
+      },
       "NestedValueSetConstraints": {
-        "description": "It has valueset constraints on a field.",
         "allOf": [
-          { "$ref": "#/definitions/Group" },
+          {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry"
+          },
+          {
+            "$ref": "#/definitions/Group"
+          },
           {
             "type": "object",
             "properties": {
@@ -32,129 +133,66 @@
               }
             }
           }
-        ]
-      },
-      "Group": {
-        "description": "It is a group of elements",
-        "concepts": [
-          { "code": "bar", "codeSystem": "http://foo.org", "displayText": "Foobar"},
-          { "code": "far", "codeSystem": "http://boo.org", "displayText": "Boofar"}
         ],
-        "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
-          {
-            "type": "object",
-            "properties": {
-              "Simple": { "$ref": "#/definitions/Simple" },
-              "Coded": { "$ref": "#/definitions/Coded" },
-              "ElementValue": {
-                "type": "array",
-                "minItems": 0,
-                "items": {
-                  "$ref": "#/definitions/ElementValue"
-                }
-              }
-            },
-            "required": ["Simple"]
-          }
-        ]
+        "description": "It has valueset constraints on a field."
       },
       "Simple": {
+        "type": "object",
+        "properties": {
+          "Value": {
+            "type": "string"
+          },
+          "EntryType": {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+          }
+        },
+        "concepts": [
+          {
+            "code": "bar",
+            "codeSystem": "http://foo.org",
+            "displayText": "Foobar"
+          }
+        ],
         "description": "It is a simple element",
-        "concepts": [ { "code": "bar", "codeSystem": "http://foo.org", "displayText": "Foobar"}],
-        "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
-          {
-            "type": "object",
-            "properties": {
-              "Value": {
-                "type": "string"
-              }
-            },
-            "required": ["Value"]
-          }
-        ]
-      },
-      "Coded": {
-        "description": "It is a coded element",
-        "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
-          {
-            "type": "object",
-            "properties": {
-              "Value": {
-                "type": "object",
-                "properties": {
-                  "code": { "type": "string" },
-                  "codeSystem": { "type": "string", "format": "uri" },
-                  "displayText": { "type": "string" }
-                },
-                "required": [ "code", "codeSystem" ],
-                "valueSet": {
-                  "uri": "http://standardhealthrecord.org/test/vs/Coded",
-                  "strength": "REQUIRED"
-                }
-              }
-            },
-            "required": ["Value"]
-          }
-        ]
-      },
-      "ForeignElementValue": {
-        "description": "It is an element with a foreign element value",
-        "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
-          {
-            "type": "object",
-            "properties": {
-              "Value": {
-                "$ref": "https://standardhealthrecord.org/test/shr/other/test#/definitions/Simple"
-              }
-            },
-            "required": ["Value"]
-          }
-        ]
-      },
-      "ElementValue": {
-        "description": "It is an element with an element value",
-        "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
-          {
-            "type": "object",
-            "properties": {
-              "Value": {
-                "$ref": "#/definitions/Simple"
-              }
-            },
-            "required": ["Value"]
-          }
+        "required": [
+          "Value",
+          "EntryType"
         ]
       }
-    }
+    },
+    "type": "object",
+    "anyOf": [
+      {
+        "$ref": "#/definitions/NestedValueSetConstraints"
+      }
+    ]
   },
   "https://standardhealthrecord.org/test/shr/other/test": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/other/test",
     "title": "TODO: Figure out what the title should be.",
-    "type": "object",
-    "anyOf": [
-      { "$ref": "#/definitions/Simple" }
-    ],
     "definitions": {
       "Simple": {
-        "description": "It is a simple element",
-        "concepts": [ { "code": "bar", "codeSystem": "http://foo.org", "displayText": "Foobar"}],
-        "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
-          {
-            "type": "object",
-            "properties": {
-              "Value": {
-                "type": "string"
-              }
-            },
-            "required": ["Value"]
+        "type": "object",
+        "properties": {
+          "Value": {
+            "type": "string"
+          },
+          "EntryType": {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
           }
+        },
+        "concepts": [
+          {
+            "code": "bar",
+            "codeSystem": "http://foo.org",
+            "displayText": "Foobar"
+          }
+        ],
+        "description": "It is a simple element",
+        "required": [
+          "Value",
+          "EntryType"
         ]
       }
     }

--- a/test/fixtures/NestedValueSetConstraints.schema.json
+++ b/test/fixtures/NestedValueSetConstraints.schema.json
@@ -1,4 +1,41 @@
 {
+  "https://standardhealthrecord.org/schema/cimpl/builtin": {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "https://standardhealthrecord.org/schema/cimpl/builtin",
+    "title": "CIMPL Builtin Schema",
+    "definitions": {
+      "Concept": {
+        "type": "object",
+        "properties": {
+          "coding": {
+            "type": "array",
+            "minItems": 0,
+            "items": {
+              "$ref": "#/definitions/Coding"
+            }
+          }
+        },
+        "required": [
+          "coding"
+        ]
+      },
+      "Coding": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "system": {
+            "type": "string",
+            "format": "uri"
+          },
+          "display": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
   "https://standardhealthrecord.org/test/shr/test": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
@@ -8,23 +45,7 @@
         "type": "object",
         "properties": {
           "Value": {
-            "type": "object",
-            "properties": {
-              "code": {
-                "type": "string"
-              },
-              "codeSystem": {
-                "type": "string",
-                "format": "uri"
-              },
-              "displayText": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "code",
-              "codeSystem"
-            ],
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/Concept",
             "valueSet": {
               "uri": "http://standardhealthrecord.org/test/vs/Coded",
               "strength": "REQUIRED"
@@ -94,14 +115,22 @@
         },
         "concepts": [
           {
-            "code": "bar",
-            "codeSystem": "http://foo.org",
-            "displayText": "Foobar"
+            "coding": [
+              {
+                "code": "bar",
+                "system": "http://foo.org",
+                "display": "Foobar"
+              }
+            ]
           },
           {
-            "code": "far",
-            "codeSystem": "http://boo.org",
-            "displayText": "Boofar"
+            "coding": [
+              {
+                "code": "far",
+                "system": "http://boo.org",
+                "display": "Boofar"
+              }
+            ]
           }
         ],
         "description": "It is a group of elements",
@@ -148,9 +177,13 @@
         },
         "concepts": [
           {
-            "code": "bar",
-            "codeSystem": "http://foo.org",
-            "displayText": "Foobar"
+            "coding": [
+              {
+                "code": "bar",
+                "system": "http://foo.org",
+                "display": "Foobar"
+              }
+            ]
           }
         ],
         "description": "It is a simple element",
@@ -184,9 +217,13 @@
         },
         "concepts": [
           {
-            "code": "bar",
-            "codeSystem": "http://foo.org",
-            "displayText": "Foobar"
+            "coding": [
+              {
+                "code": "bar",
+                "system": "http://foo.org",
+                "display": "Foobar"
+              }
+            ]
           }
         ],
         "description": "It is a simple element",

--- a/test/fixtures/NotDone.schema.json
+++ b/test/fixtures/NotDone.schema.json
@@ -1,27 +1,82 @@
 {
+  "https://standardhealthrecord.org/schema/cimpl/builtin": {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "https://standardhealthrecord.org/schema/cimpl/builtin",
+    "title": "CIMPL Builtin Schema",
+    "definitions": {
+      "Concept": {
+        "type": "object",
+        "properties": {
+          "coding": {
+            "type": "array",
+            "minItems": 0,
+            "items": {
+              "$ref": "#/definitions/Coding"
+            }
+          }
+        },
+        "required": [
+          "coding"
+        ]
+      },
+      "Coding": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "system": {
+            "type": "string",
+            "format": "uri"
+          },
+          "display": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
   "https://standardhealthrecord.org/test/shr/test": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
     "title": "TODO: Figure out what the title should be.",
-    "type": "object",
-    "anyOf": [
-      { "$ref": "#/definitions/NotDone" }
-    ],
     "definitions": {
       "NotDone": {
-        "description": "It is an unfinished element\nTBD Fields: An undetermined list field.\nAn undetermined singular field.\nTBD with cardinality 1..*",
-        "concepts": [ { "code": "bar", "codeSystem": "http://foo.org", "displayText": "Foobar"}],
         "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
+          {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry"
+          },
           {
             "type": "object",
             "properties": {
-              "Value": { "description": "TBD: An undetermined value." }
+              "Value": {
+                "description": "TBD: An undetermined value."
+              }
             },
-            "required": [ "Value" ]
+            "required": [
+              "Value"
+            ]
           }
-        ]
+        ],
+        "concepts": [
+          {
+            "coding": [
+              {
+                "code": "bar",
+                "system": "http://foo.org",
+                "display": "Foobar"
+              }
+            ]
+          }
+        ],
+        "description": "It is an unfinished element\nTBD Fields: An undetermined list field.\nAn undetermined singular field.\nTBD with cardinality 1..*"
       }
-    }
+    },
+    "type": "object",
+    "anyOf": [
+      {
+        "$ref": "#/definitions/NotDone"
+      }
+    ]
   }
 }

--- a/test/fixtures/NotDoneDerivative.schema.json
+++ b/test/fixtures/NotDoneDerivative.schema.json
@@ -3,18 +3,15 @@
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
     "title": "TODO: Figure out what the title should be.",
-    "type": "object",
-    "anyOf": [
-      { "$ref": "#/definitions/NotDoneDerivative" },
-      { "$ref": "#/definitions/Simple" },
-      { "$ref": "#/definitions/ValuelessElement" }
-    ],
     "definitions": {
       "NotDoneDerivative": {
-        "description": "It is an unfinished derivative element\nTBD Parents: An undetermined parent.\nTBD\nTBD Fields: An undetermined singular field.",
-        "concepts": [ { "code": "TBD", "codeSystem": "urn:tbd", "displayText": "Not sure of the concept"}],
         "allOf": [
-          { "$ref": "#/definitions/ValuelessElement" },
+          {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry"
+          },
+          {
+            "$ref": "#/definitions/ValuelessElement"
+          },
           {
             "type": "object",
             "properties": {
@@ -25,39 +22,61 @@
               }
             }
           }
+        ],
+        "concepts": [
+          {
+            "code": "TBD",
+            "codeSystem": "urn:tbd",
+            "displayText": "Not sure of the concept"
+          }
+        ],
+        "description": "It is an unfinished derivative element\nTBD Parents: An undetermined parent.\nTBD\nTBD Fields: An undetermined singular field."
+      },
+      "Simple": {
+        "type": "object",
+        "properties": {
+          "Value": {
+            "type": "string"
+          },
+          "EntryType": {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+          }
+        },
+        "concepts": [
+          {
+            "code": "bar",
+            "codeSystem": "http://foo.org",
+            "displayText": "Foobar"
+          }
+        ],
+        "description": "It is a simple element",
+        "required": [
+          "Value",
+          "EntryType"
         ]
       },
       "ValuelessElement": {
+        "type": "object",
+        "properties": {
+          "Simple": {
+            "$ref": "#/definitions/Simple"
+          },
+          "EntryType": {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+          }
+        },
         "description": "An element with no value.",
-        "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
-          {
-            "type": "object",
-            "properties": {
-              "Simple": {
-                "$ref": "#/definitions/Simple"
-              }
-            },
-            "required": [ "Simple" ]
-          }
-        ]
-      },
-      "Simple": {
-        "description": "It is a simple element",
-        "concepts": [ { "code": "bar", "codeSystem": "http://foo.org", "displayText": "Foobar"}],
-        "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
-          {
-            "type": "object",
-            "properties": {
-              "Value": {
-                "type": "string"
-              }
-            },
-            "required": [ "Value" ]
-          }
+        "required": [
+          "Simple",
+          "EntryType"
         ]
       }
-    }
+    },
+    "type": "object",
+    "anyOf": [
+      {
+        "$ref": "#/definitions/NotDoneDerivative"
+      }
+    ]
   }
 }

--- a/test/fixtures/NotDoneDerivative.schema.json
+++ b/test/fixtures/NotDoneDerivative.schema.json
@@ -1,4 +1,41 @@
 {
+  "https://standardhealthrecord.org/schema/cimpl/builtin": {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "https://standardhealthrecord.org/schema/cimpl/builtin",
+    "title": "CIMPL Builtin Schema",
+    "definitions": {
+      "Concept": {
+        "type": "object",
+        "properties": {
+          "coding": {
+            "type": "array",
+            "minItems": 0,
+            "items": {
+              "$ref": "#/definitions/Coding"
+            }
+          }
+        },
+        "required": [
+          "coding"
+        ]
+      },
+      "Coding": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "system": {
+            "type": "string",
+            "format": "uri"
+          },
+          "display": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
   "https://standardhealthrecord.org/test/shr/test": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
@@ -25,9 +62,13 @@
         ],
         "concepts": [
           {
-            "code": "TBD",
-            "codeSystem": "urn:tbd",
-            "displayText": "Not sure of the concept"
+            "coding": [
+              {
+                "code": "TBD",
+                "system": "urn:tbd",
+                "display": "Not sure of the concept"
+              }
+            ]
           }
         ],
         "description": "It is an unfinished derivative element\nTBD Parents: An undetermined parent.\nTBD\nTBD Fields: An undetermined singular field."
@@ -44,9 +85,13 @@
         },
         "concepts": [
           {
-            "code": "bar",
-            "codeSystem": "http://foo.org",
-            "displayText": "Foobar"
+            "coding": [
+              {
+                "code": "bar",
+                "system": "http://foo.org",
+                "display": "Foobar"
+              }
+            ]
           }
         ],
         "description": "It is a simple element",

--- a/test/fixtures/ReferenceChoice.schema.json
+++ b/test/fixtures/ReferenceChoice.schema.json
@@ -3,33 +3,133 @@
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
     "title": "TODO: Figure out what the title should be.",
-    "type": "object",
-    "anyOf": [
-      { "$ref": "#/definitions/ReferenceChoice" }
-    ],
     "definitions": {
-      "ReferenceChoice": {
-        "description": "It is a reference to one of a few types",
+      "Coded": {
         "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
+          {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry"
+          },
           {
             "type": "object",
             "properties": {
               "Value": {
                 "type": "object",
                 "properties": {
-                  "_ShrId": { "type": "string" },
-                  "_EntryType": { "type": "string" },
-                  "_EntryId": { "type": "string" }
+                  "code": {
+                    "type": "string"
+                  },
+                  "codeSystem": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "displayText": {
+                    "type": "string"
+                  }
                 },
-                "required": ["_ShrId", "_EntryType", "_EntryId"],
-                "refType": ["http://standardhealthrecord.org/spec/shr/other/test/Simple", "http://standardhealthrecord.org/spec/shr/test/Coded"]
+                "required": [
+                  "code",
+                  "codeSystem"
+                ],
+                "valueSet": {
+                  "uri": "http://standardhealthrecord.org/test/vs/Coded",
+                  "strength": "REQUIRED"
+                }
               }
             },
-            "required": ["Value"]
+            "required": [
+              "Value"
+            ]
           }
-        ]
+        ],
+        "description": "It is a coded element"
+      },
+      "ReferenceChoice": {
+        "allOf": [
+          {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "Value": {
+                "type": "object",
+                "properties": {
+                  "_ShrId": {
+                    "type": "string"
+                  },
+                  "_EntryId": {
+                    "type": "string"
+                  },
+                  "_EntryType": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "_ShrId",
+                  "_EntryType",
+                  "_EntryId"
+                ],
+                "refType": [
+                  "http://standardhealthrecord.org/spec/shr/other/test/Simple",
+                  "http://standardhealthrecord.org/spec/shr/test/Coded"
+                ]
+              }
+            },
+            "required": [
+              "Value"
+            ]
+          }
+        ],
+        "description": "It is a reference to one of a few types"
       }
-    }
+    },
+    "type": "object",
+    "anyOf": [
+      {
+        "$ref": "#/definitions/Coded"
+      },
+      {
+        "$ref": "#/definitions/ReferenceChoice"
+      }
+    ]
+  },
+  "https://standardhealthrecord.org/test/shr/other/test": {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "https://standardhealthrecord.org/test/shr/other/test",
+    "title": "TODO: Figure out what the title should be.",
+    "definitions": {
+      "Simple": {
+        "allOf": [
+          {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "Value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "Value"
+            ]
+          }
+        ],
+        "concepts": [
+          {
+            "code": "bar",
+            "codeSystem": "http://foo.org",
+            "displayText": "Foobar"
+          }
+        ],
+        "description": "It is a simple element"
+      }
+    },
+    "type": "object",
+    "anyOf": [
+      {
+        "$ref": "#/definitions/Simple"
+      }
+    ]
   }
 }

--- a/test/fixtures/ReferenceChoice.schema.json
+++ b/test/fixtures/ReferenceChoice.schema.json
@@ -1,4 +1,41 @@
 {
+  "https://standardhealthrecord.org/schema/cimpl/builtin": {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "https://standardhealthrecord.org/schema/cimpl/builtin",
+    "title": "CIMPL Builtin Schema",
+    "definitions": {
+      "Concept": {
+        "type": "object",
+        "properties": {
+          "coding": {
+            "type": "array",
+            "minItems": 0,
+            "items": {
+              "$ref": "#/definitions/Coding"
+            }
+          }
+        },
+        "required": [
+          "coding"
+        ]
+      },
+      "Coding": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "system": {
+            "type": "string",
+            "format": "uri"
+          },
+          "display": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
   "https://standardhealthrecord.org/test/shr/test": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
@@ -13,23 +50,7 @@
             "type": "object",
             "properties": {
               "Value": {
-                "type": "object",
-                "properties": {
-                  "code": {
-                    "type": "string"
-                  },
-                  "codeSystem": {
-                    "type": "string",
-                    "format": "uri"
-                  },
-                  "displayText": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "code",
-                  "codeSystem"
-                ],
+                "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/Concept",
                 "valueSet": {
                   "uri": "http://standardhealthrecord.org/test/vs/Coded",
                   "strength": "REQUIRED"
@@ -117,9 +138,13 @@
         ],
         "concepts": [
           {
-            "code": "bar",
-            "codeSystem": "http://foo.org",
-            "displayText": "Foobar"
+            "coding": [
+              {
+                "code": "bar",
+                "system": "http://foo.org",
+                "display": "Foobar"
+              }
+            ]
           }
         ],
         "description": "It is a simple element"

--- a/test/fixtures/Simple.schema.json
+++ b/test/fixtures/Simple.schema.json
@@ -1,18 +1,51 @@
 {
+  "https://standardhealthrecord.org/schema/cimpl/builtin": {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "https://standardhealthrecord.org/schema/cimpl/builtin",
+    "title": "CIMPL Builtin Schema",
+    "definitions": {
+      "Concept": {
+        "type": "object",
+        "properties": {
+          "coding": {
+            "type": "array",
+            "minItems": 0,
+            "items": {
+              "$ref": "#/definitions/Coding"
+            }
+          }
+        },
+        "required": [
+          "coding"
+        ]
+      },
+      "Coding": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "system": {
+            "type": "string",
+            "format": "uri"
+          },
+          "display": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
   "https://standardhealthrecord.org/test/shr/test": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
     "title": "TODO: Figure out what the title should be.",
-    "type": "object",
-    "anyOf": [
-      { "$ref": "#/definitions/Simple" }
-    ],
     "definitions": {
       "Simple": {
-        "description": "It is a simple element",
-        "concepts": [ { "code": "bar", "codeSystem": "http://foo.org", "displayText": "Foobar"}],
         "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
+          {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry"
+          },
           {
             "type": "object",
             "properties": {
@@ -20,10 +53,30 @@
                 "type": "string"
               }
             },
-            "required": ["Value"]
+            "required": [
+              "Value"
+            ]
           }
-        ]
+        ],
+        "concepts": [
+          {
+            "coding": [
+              {
+                "code": "bar",
+                "system": "http://foo.org",
+                "display": "Foobar"
+              }
+            ]
+          }
+        ],
+        "description": "It is a simple element"
       }
-    }
+    },
+    "type": "object",
+    "anyOf": [
+      {
+        "$ref": "#/definitions/Simple"
+      }
+    ]
   }
 }

--- a/test/fixtures/SimpleReference.schema.json
+++ b/test/fixtures/SimpleReference.schema.json
@@ -1,4 +1,41 @@
 {
+  "https://standardhealthrecord.org/schema/cimpl/builtin": {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "https://standardhealthrecord.org/schema/cimpl/builtin",
+    "title": "CIMPL Builtin Schema",
+    "definitions": {
+      "Concept": {
+        "type": "object",
+        "properties": {
+          "coding": {
+            "type": "array",
+            "minItems": 0,
+            "items": {
+              "$ref": "#/definitions/Coding"
+            }
+          }
+        },
+        "required": [
+          "coding"
+        ]
+      },
+      "Coding": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "system": {
+            "type": "string",
+            "format": "uri"
+          },
+          "display": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
   "https://standardhealthrecord.org/test/shr/test": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
@@ -23,9 +60,13 @@
         ],
         "concepts": [
           {
-            "code": "bar",
-            "codeSystem": "http://foo.org",
-            "displayText": "Foobar"
+            "coding": [
+              {
+                "code": "bar",
+                "system": "http://foo.org",
+                "display": "Foobar"
+              }
+            ]
           }
         ],
         "description": "It is a simple element"

--- a/test/fixtures/SimpleReference.schema.json
+++ b/test/fixtures/SimpleReference.schema.json
@@ -3,33 +3,80 @@
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
     "title": "TODO: Figure out what the title should be.",
-    "type": "object",
-    "anyOf": [
-      { "$ref": "#/definitions/SimpleReference" }
-    ],
     "definitions": {
-      "SimpleReference": {
-        "description": "It is a reference to a simple element",
+      "Simple": {
         "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
+          {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "Value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "Value"
+            ]
+          }
+        ],
+        "concepts": [
+          {
+            "code": "bar",
+            "codeSystem": "http://foo.org",
+            "displayText": "Foobar"
+          }
+        ],
+        "description": "It is a simple element"
+      },
+      "SimpleReference": {
+        "allOf": [
+          {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry"
+          },
           {
             "type": "object",
             "properties": {
               "Value": {
                 "type": "object",
                 "properties": {
-                  "_ShrId": { "type": "string" },
-                  "_EntryType": { "type": "string" },
-                  "_EntryId": { "type": "string" }
+                  "_ShrId": {
+                    "type": "string"
+                  },
+                  "_EntryId": {
+                    "type": "string"
+                  },
+                  "_EntryType": {
+                    "type": "string"
+                  }
                 },
-                "required": ["_ShrId", "_EntryType", "_EntryId"],
-                "refType": ["http://standardhealthrecord.org/spec/shr/test/Simple"]
+                "required": [
+                  "_ShrId",
+                  "_EntryType",
+                  "_EntryId"
+                ],
+                "refType": [
+                  "http://standardhealthrecord.org/spec/shr/test/Simple"
+                ]
               }
             },
-            "required": ["Value"]
+            "required": [
+              "Value"
+            ]
           }
-        ]
+        ],
+        "description": "It is a reference to a simple element"
       }
-    }
+    },
+    "type": "object",
+    "anyOf": [
+      {
+        "$ref": "#/definitions/Simple"
+      },
+      {
+        "$ref": "#/definitions/SimpleReference"
+      }
+    ]
   }
 }

--- a/test/fixtures/TwoDeepElementValue.schema.json
+++ b/test/fixtures/TwoDeepElementValue.schema.json
@@ -1,4 +1,41 @@
 {
+  "https://standardhealthrecord.org/schema/cimpl/builtin": {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "https://standardhealthrecord.org/schema/cimpl/builtin",
+    "title": "CIMPL Builtin Schema",
+    "definitions": {
+      "Concept": {
+        "type": "object",
+        "properties": {
+          "coding": {
+            "type": "array",
+            "minItems": 0,
+            "items": {
+              "$ref": "#/definitions/Coding"
+            }
+          }
+        },
+        "required": [
+          "coding"
+        ]
+      },
+      "Coding": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "system": {
+            "type": "string",
+            "format": "uri"
+          },
+          "display": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
   "https://standardhealthrecord.org/test/shr/test": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
@@ -32,9 +69,13 @@
         },
         "concepts": [
           {
-            "code": "bar",
-            "codeSystem": "http://foo.org",
-            "displayText": "Foobar"
+            "coding": [
+              {
+                "code": "bar",
+                "system": "http://foo.org",
+                "display": "Foobar"
+              }
+            ]
           }
         ],
         "description": "It is a simple element",

--- a/test/fixtures/TwoDeepElementValue.schema.json
+++ b/test/fixtures/TwoDeepElementValue.schema.json
@@ -3,17 +3,51 @@
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
     "title": "TODO: Figure out what the title should be.",
-    "type": "object",
-    "anyOf": [
-      { "$ref": "#/definitions/ElementValue" },
-      { "$ref": "#/definitions/Simple" },
-      { "$ref": "#/definitions/TwoDeepElementValue" }
-    ],
     "definitions": {
+      "ElementValue": {
+        "type": "object",
+        "properties": {
+          "Value": {
+            "$ref": "#/definitions/Simple"
+          },
+          "EntryType": {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+          }
+        },
+        "description": "It is an element with an element value",
+        "required": [
+          "Value",
+          "EntryType"
+        ]
+      },
+      "Simple": {
+        "type": "object",
+        "properties": {
+          "Value": {
+            "type": "string"
+          },
+          "EntryType": {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+          }
+        },
+        "concepts": [
+          {
+            "code": "bar",
+            "codeSystem": "http://foo.org",
+            "displayText": "Foobar"
+          }
+        ],
+        "description": "It is a simple element",
+        "required": [
+          "Value",
+          "EntryType"
+        ]
+      },
       "TwoDeepElementValue": {
-        "description": "It is an element with a two-deep element value",
         "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
+          {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry"
+          },
           {
             "type": "object",
             "properties": {
@@ -21,41 +55,19 @@
                 "$ref": "#/definitions/ElementValue"
               }
             },
-            "required": ["Value"]
+            "required": [
+              "Value"
+            ]
           }
-        ]
-      },
-      "ElementValue": {
-        "description": "It is an element with an element value",
-        "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
-          {
-            "type": "object",
-            "properties": {
-              "Value": {
-                "$ref": "#/definitions/Simple"
-              }
-            },
-            "required": ["Value"]
-          }
-        ]
-      },
-      "Simple": {
-        "description": "It is a simple element",
-        "concepts": [ { "code": "bar", "codeSystem": "http://foo.org", "displayText": "Foobar"}],
-        "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
-          {
-            "type": "object",
-            "properties": {
-              "Value": {
-                "type": "string"
-              }
-            },
-            "required": ["Value"]
-          }
-        ]
+        ],
+        "description": "It is an element with a two-deep element value"
       }
-    }
+    },
+    "type": "object",
+    "anyOf": [
+      {
+        "$ref": "#/definitions/TwoDeepElementValue"
+      }
+    ]
   }
 }

--- a/test/fixtures/TypeConstrainedChoices.schema.json
+++ b/test/fixtures/TypeConstrainedChoices.schema.json
@@ -1,4 +1,41 @@
 {
+  "https://standardhealthrecord.org/schema/cimpl/builtin": {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "https://standardhealthrecord.org/schema/cimpl/builtin",
+    "title": "CIMPL Builtin Schema",
+    "definitions": {
+      "Concept": {
+        "type": "object",
+        "properties": {
+          "coding": {
+            "type": "array",
+            "minItems": 0,
+            "items": {
+              "$ref": "#/definitions/Coding"
+            }
+          }
+        },
+        "required": [
+          "coding"
+        ]
+      },
+      "Coding": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "system": {
+            "type": "string",
+            "format": "uri"
+          },
+          "display": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
   "https://standardhealthrecord.org/test/shr/test": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
@@ -13,23 +50,7 @@
                 "type": "string"
               },
               {
-                "type": "object",
-                "properties": {
-                  "code": {
-                    "type": "string"
-                  },
-                  "codeSystem": {
-                    "type": "string",
-                    "format": "uri"
-                  },
-                  "displayText": {
-                    "type": "string"
-                  }
-                },
-                "required": [
-                  "code",
-                  "codeSystem"
-                ],
+                "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/Concept",
                 "valueSet": {
                   "uri": "http://standardhealthrecord.org/test/vs/CodeChoice",
                   "strength": "REQUIRED"
@@ -70,23 +91,7 @@
         "type": "object",
         "properties": {
           "Value": {
-            "type": "object",
-            "properties": {
-              "code": {
-                "type": "string"
-              },
-              "codeSystem": {
-                "type": "string",
-                "format": "uri"
-              },
-              "displayText": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "code",
-              "codeSystem"
-            ],
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/Concept",
             "valueSet": {
               "uri": "http://standardhealthrecord.org/test/vs/Coded",
               "strength": "REQUIRED"

--- a/test/fixtures/TypeConstrainedChoices.schema.json
+++ b/test/fixtures/TypeConstrainedChoices.schema.json
@@ -3,42 +3,152 @@
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
     "title": "TODO: Figure out what the title should be.",
-    "type": "object",
-    "anyOf": [
-      { "$ref": "#/definitions/Choice" },
-      { "$ref": "#/definitions/ChoiceValue" },
-      { "$ref": "#/definitions/Coded" },
-      { "$ref": "#/definitions/TwoDeepChoiceField" },
-      { "$ref": "#/definitions/TypeConstrainedChoice"},
-      { "$ref": "#/definitions/TypeConstrainedChoiceWithPath"}
-    ],
     "definitions": {
-      "TypeConstrainedChoice": {
-        "description": "It is an element with a choice with a constraint.",
-        "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
-          {
+      "Choice": {
+        "type": "object",
+        "properties": {
+          "Value": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "code": {
+                    "type": "string"
+                  },
+                  "codeSystem": {
+                    "type": "string",
+                    "format": "uri"
+                  },
+                  "displayText": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "code",
+                  "codeSystem"
+                ],
+                "valueSet": {
+                  "uri": "http://standardhealthrecord.org/test/vs/CodeChoice",
+                  "strength": "REQUIRED"
+                }
+              },
+              {
+                "$ref": "#/definitions/Coded"
+              }
+            ]
+          },
+          "EntryType": {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+          }
+        },
+        "description": "It is an element with a choice",
+        "required": [
+          "Value",
+          "EntryType"
+        ]
+      },
+      "ChoiceValue": {
+        "type": "object",
+        "properties": {
+          "Value": {
+            "$ref": "#/definitions/Choice"
+          },
+          "EntryType": {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+          }
+        },
+        "description": "It is an element with a choice value.",
+        "required": [
+          "Value",
+          "EntryType"
+        ]
+      },
+      "Coded": {
+        "type": "object",
+        "properties": {
+          "Value": {
             "type": "object",
             "properties": {
-              "Choice": {
-                "allOf": [
-                  {
-                    "properties": {
-                      "Value": { "type": "string" }
-                    }
-                  },
-                  { "$ref": "#/definitions/Choice" }
-                ]
+              "code": {
+                "type": "string"
+              },
+              "codeSystem": {
+                "type": "string",
+                "format": "uri"
+              },
+              "displayText": {
+                "type": "string"
               }
             },
-            "required": ["Choice"]
+            "required": [
+              "code",
+              "codeSystem"
+            ],
+            "valueSet": {
+              "uri": "http://standardhealthrecord.org/test/vs/Coded",
+              "strength": "REQUIRED"
+            }
+          },
+          "EntryType": {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
           }
+        },
+        "description": "It is a coded element",
+        "required": [
+          "Value",
+          "EntryType"
+        ]
+      },
+      "TwoDeepChoiceField": {
+        "type": "object",
+        "properties": {
+          "ChoiceValue": {
+            "$ref": "#/definitions/ChoiceValue"
+          },
+          "EntryType": {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+          }
+        },
+        "description": "It is an element with a a field with a choice.",
+        "required": [
+          "EntryType"
+        ]
+      },
+      "TypeConstrainedChoice": {
+        "type": "object",
+        "properties": {
+          "Choice": {
+            "allOf": [
+              {
+                "properties": {
+                  "Value": {
+                    "type": "string"
+                  }
+                }
+              },
+              {
+                "$ref": "#/definitions/Choice"
+              }
+            ]
+          },
+          "EntryType": {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+          }
+        },
+        "description": "It is an element with a choice with a constraint.",
+        "required": [
+          "Choice",
+          "EntryType"
         ]
       },
       "TypeConstrainedChoiceWithPath": {
-        "description": "It is an element with a choice on a field with a constraint.",
         "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
+          {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry"
+          },
           {
             "type": "object",
             "properties": {
@@ -50,101 +160,31 @@
                         "properties": {
                           "Value": {
                             "properties": {
-                              "Value": { "$ref": "#/definitions/Coded" }
+                              "Value": {
+                                "$ref": "#/definitions/Coded"
+                              }
                             }
                           }
                         }
                       }
                     }
                   },
-                  { "$ref": "#/definitions/TwoDeepChoiceField" }
-                ]
-              }
-            }
-          }
-        ]
-      },
-      "ChoiceValue": {
-        "description": "It is an element with a choice value.",
-        "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
-          {
-            "type": "object",
-            "properties": {
-              "Value": { "$ref": "#/definitions/Choice" }
-            },
-            "required": ["Value"]
-          }
-        ]
-      },
-      "TwoDeepChoiceField": {
-        "description": "It is an element with a a field with a choice.",
-        "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
-          {
-            "type": "object",
-            "properties": {
-              "ChoiceValue": { "$ref": "#/definitions/ChoiceValue" }
-            }
-          }
-        ]
-      },
-      "Choice": {
-        "description": "It is an element with a choice",
-        "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
-          {
-            "type": "object",
-            "properties": {
-              "Value": {
-                "anyOf": [
-                  { "type": "string" },
                   {
-                    "type": "object",
-                    "properties": {
-                      "code": { "type": "string" },
-                      "codeSystem": { "type": "string", "format": "uri" },
-                      "displayText": { "type": "string" }
-                    },
-                    "required": [ "code", "codeSystem" ],
-                    "valueSet": {
-                      "uri": "http://standardhealthrecord.org/test/vs/CodeChoice",
-                      "strength": "REQUIRED"
-                    }
-                  },
-                  { "$ref": "#/definitions/Coded" }
+                    "$ref": "#/definitions/TwoDeepChoiceField"
+                  }
                 ]
               }
-            },
-            "required": ["Value"]
+            }
           }
-        ]
-      },
-      "Coded": {
-        "description": "It is a coded element",
-        "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
-          {
-            "type": "object",
-            "properties": {
-              "Value": {
-                "type": "object",
-                "properties": {
-                  "code": { "type": "string" },
-                  "codeSystem": { "type": "string", "format": "uri" },
-                  "displayText": { "type": "string" }
-                },
-                "required": [ "code", "codeSystem" ],
-                "valueSet": {
-                  "uri": "http://standardhealthrecord.org/test/vs/Coded",
-                  "strength": "REQUIRED"
-                }
-              }
-            },
-            "required": ["Value"]
-          }
-        ]
+        ],
+        "description": "It is an element with a choice on a field with a constraint."
       }
-    }
+    },
+    "type": "object",
+    "anyOf": [
+      {
+        "$ref": "#/definitions/TypeConstrainedChoiceWithPath"
+      }
+    ]
   }
 }

--- a/test/fixtures/TypeConstrainedReference.schema.json
+++ b/test/fixtures/TypeConstrainedReference.schema.json
@@ -1,4 +1,41 @@
 {
+  "https://standardhealthrecord.org/schema/cimpl/builtin": {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "https://standardhealthrecord.org/schema/cimpl/builtin",
+    "title": "CIMPL Builtin Schema",
+    "definitions": {
+      "Concept": {
+        "type": "object",
+        "properties": {
+          "coding": {
+            "type": "array",
+            "minItems": 0,
+            "items": {
+              "$ref": "#/definitions/Coding"
+            }
+          }
+        },
+        "required": [
+          "coding"
+        ]
+      },
+      "Coding": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "system": {
+            "type": "string",
+            "format": "uri"
+          },
+          "display": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
   "https://standardhealthrecord.org/test/shr/test": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
@@ -23,9 +60,13 @@
         ],
         "concepts": [
           {
-            "code": "bar",
-            "codeSystem": "http://foo.org",
-            "displayText": "Foobar"
+            "coding": [
+              {
+                "code": "bar",
+                "system": "http://foo.org",
+                "display": "Foobar"
+              }
+            ]
           }
         ],
         "description": "It is a simple element"

--- a/test/fixtures/TypeConstrainedReference.schema.json
+++ b/test/fixtures/TypeConstrainedReference.schema.json
@@ -3,18 +3,88 @@
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
     "title": "TODO: Figure out what the title should be.",
-    "type": "object",
-    "anyOf": [
-      { "$ref": "#/definitions/Simple" },
-      { "$ref": "#/definitions/SimpleChild" },
-      { "$ref": "#/definitions/SimpleReference" },
-      { "$ref": "#/definitions/TypeConstrainedReference" }
-    ],
     "definitions": {
-      "TypeConstrainedReference": {
-        "description": "It is an element a constraint on a reference.",
+      "Simple": {
         "allOf": [
-          { "$ref": "#/definitions/SimpleReference" },
+          {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "Value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "Value"
+            ]
+          }
+        ],
+        "concepts": [
+          {
+            "code": "bar",
+            "codeSystem": "http://foo.org",
+            "displayText": "Foobar"
+          }
+        ],
+        "description": "It is a simple element"
+      },
+      "SimpleChild": {
+        "allOf": [
+          {
+            "$ref": "#/definitions/Simple"
+          },
+          {
+            "type": "object",
+            "properties": {}
+          }
+        ],
+        "description": "A derivative of the simple type."
+      },
+      "SimpleReference": {
+        "type": "object",
+        "properties": {
+          "Value": {
+            "type": "object",
+            "properties": {
+              "_ShrId": {
+                "type": "string"
+              },
+              "_EntryId": {
+                "type": "string"
+              },
+              "_EntryType": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "_ShrId",
+              "_EntryType",
+              "_EntryId"
+            ],
+            "refType": [
+              "http://standardhealthrecord.org/spec/shr/test/Simple"
+            ]
+          },
+          "EntryType": {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+          }
+        },
+        "description": "It is a reference to a simple element",
+        "required": [
+          "Value",
+          "EntryType"
+        ]
+      },
+      "TypeConstrainedReference": {
+        "allOf": [
+          {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry"
+          },
+          {
+            "$ref": "#/definitions/SimpleReference"
+          },
           {
             "type": "object",
             "properties": {
@@ -23,69 +93,52 @@
                   {
                     "type": "object",
                     "properties": {
-                      "_ShrId": { "type": "string" },
-                      "_EntryType": { "type": "string" },
-                      "_EntryId": { "type": "string" }
+                      "_ShrId": {
+                        "type": "string"
+                      },
+                      "_EntryId": {
+                        "type": "string"
+                      },
+                      "_EntryType": {
+                        "type": "string"
+                      }
                     },
-                    "required": ["_ShrId", "_EntryType", "_EntryId"],
-                    "refType": ["http://standardhealthrecord.org/spec/shr/test/Simple"]
+                    "required": [
+                      "_ShrId",
+                      "_EntryType",
+                      "_EntryId"
+                    ],
+                    "refType": [
+                      "http://standardhealthrecord.org/spec/shr/test/Simple"
+                    ]
                   },
-                  { "refType": ["http://standardhealthrecord.org/spec/shr/test/SimpleChild"] }
+                  {
+                    "refType": [
+                      "http://standardhealthrecord.org/spec/shr/test/SimpleChild"
+                    ]
+                  }
                 ]
               }
             },
-            "required": ["Value"]
+            "required": [
+              "Value"
+            ]
           }
-        ]
-      },
-      "Simple": {
-        "description": "It is a simple element",
-        "concepts": [ { "code": "bar", "codeSystem": "http://foo.org", "displayText": "Foobar"}],
-        "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
-          {
-            "type": "object",
-            "properties": {
-              "Value": {
-                "type": "string"
-              }
-            },
-            "required": ["Value"]
-          }
-        ]
-      },
-      "SimpleChild": {
-        "description": "A derivative of the simple type.",
-        "allOf": [
-          { "$ref": "#/definitions/Simple" },
-          {
-            "type": "object",
-            "properties": {}
-          }
-        ]
-      },
-      "SimpleReference": {
-        "description": "It is a reference to a simple element",
-        "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
-          {
-            "type": "object",
-            "properties": {
-              "Value": {
-                "type": "object",
-                "properties": {
-                  "_ShrId": { "type": "string" },
-                  "_EntryType": { "type": "string" },
-                  "_EntryId": { "type": "string" }
-                },
-                "required": ["_ShrId", "_EntryType", "_EntryId"],
-                "refType": ["http://standardhealthrecord.org/spec/shr/test/Simple"]
-              }
-            },
-            "required": ["Value"]
-          }
-        ]
+        ],
+        "description": "It is an element a constraint on a reference."
       }
-    }
+    },
+    "type": "object",
+    "anyOf": [
+      {
+        "$ref": "#/definitions/Simple"
+      },
+      {
+        "$ref": "#/definitions/SimpleChild"
+      },
+      {
+        "$ref": "#/definitions/TypeConstrainedReference"
+      }
+    ]
   }
 }

--- a/test/fixtures/TypeConstraints.schema.json
+++ b/test/fixtures/TypeConstraints.schema.json
@@ -3,168 +3,215 @@
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
     "title": "TODO: Figure out what the title should be.",
-    "type": "object",
-    "anyOf": [
-      { "$ref": "#/definitions/Coded" },
-      { "$ref": "#/definitions/ElementValue" },
-      { "$ref": "#/definitions/ForeignElementValue" },
-      { "$ref": "#/definitions/Group" },
-      { "$ref": "#/definitions/GroupDerivative" },
-      { "$ref": "#/definitions/Simple" },
-      { "$ref": "#/definitions/SimpleChild" }
-    ],
     "definitions": {
+      "Coded": {
+        "type": "object",
+        "properties": {
+          "Value": {
+            "type": "object",
+            "properties": {
+              "code": {
+                "type": "string"
+              },
+              "codeSystem": {
+                "type": "string",
+                "format": "uri"
+              },
+              "displayText": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "code",
+              "codeSystem"
+            ],
+            "valueSet": {
+              "uri": "http://standardhealthrecord.org/test/vs/Coded",
+              "strength": "REQUIRED"
+            }
+          },
+          "EntryType": {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+          }
+        },
+        "description": "It is a coded element",
+        "required": [
+          "Value",
+          "EntryType"
+        ]
+      },
+      "ElementValue": {
+        "type": "object",
+        "properties": {
+          "Value": {
+            "$ref": "#/definitions/Simple"
+          },
+          "EntryType": {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+          }
+        },
+        "description": "It is an element with an element value",
+        "required": [
+          "Value",
+          "EntryType"
+        ]
+      },
+      "ForeignElementValue": {
+        "type": "object",
+        "properties": {
+          "Value": {
+            "$ref": "https://standardhealthrecord.org/test/shr/other/test#/definitions/Simple"
+          },
+          "EntryType": {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+          }
+        },
+        "description": "It is an element with a foreign element value",
+        "required": [
+          "Value",
+          "EntryType"
+        ]
+      },
+      "Group": {
+        "type": "object",
+        "properties": {
+          "Simple": {
+            "$ref": "#/definitions/Simple"
+          },
+          "Coded": {
+            "$ref": "#/definitions/Coded"
+          },
+          "ElementValue": {
+            "type": "array",
+            "minItems": 0,
+            "items": {
+              "$ref": "#/definitions/ElementValue"
+            }
+          },
+          "EntryType": {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+          }
+        },
+        "concepts": [
+          {
+            "code": "bar",
+            "codeSystem": "http://foo.org",
+            "displayText": "Foobar"
+          },
+          {
+            "code": "far",
+            "codeSystem": "http://boo.org",
+            "displayText": "Boofar"
+          }
+        ],
+        "description": "It is a group of elements",
+        "required": [
+          "Simple",
+          "EntryType"
+        ]
+      },
       "GroupDerivative": {
-        "description": "It is a derivative of a group of elements with type constraints.",
         "allOf": [
-          { "$ref": "#/definitions/Group" },
+          {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry"
+          },
+          {
+            "$ref": "#/definitions/Group"
+          },
           {
             "type": "object",
             "properties": {
-              "Simple": { "$ref": "#/definitions/SimpleChild" },
+              "Simple": {
+                "$ref": "#/definitions/SimpleChild"
+              },
               "ElementValue": {
                 "type": "array",
                 "minItems": 0,
                 "items": {
                   "properties": {
-                    "Value": { "$ref": "#/definitions/SimpleChild" }
+                    "Value": {
+                      "$ref": "#/definitions/SimpleChild"
+                    }
                   }
                 }
               }
             },
-            "required": ["Simple"]
+            "required": [
+              "Simple"
+            ]
           }
-        ]
-      },
-      "Group": {
-        "description": "It is a group of elements",
-        "concepts": [
-          { "code": "bar", "codeSystem": "http://foo.org", "displayText": "Foobar"},
-          { "code": "far", "codeSystem": "http://boo.org", "displayText": "Boofar"}
         ],
-        "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
-          {
-            "type": "object",
-            "properties": {
-              "Simple": { "$ref": "#/definitions/Simple" },
-              "Coded": { "$ref": "#/definitions/Coded" },
-              "ElementValue": {
-                "type": "array",
-                "minItems": 0,
-                "items": { "$ref": "#/definitions/ElementValue" }
-              }
-            },
-            "required": ["Simple"]
-          }
-        ]
+        "description": "It is a derivative of a group of elements with type constraints."
       },
       "Simple": {
-        "description": "It is a simple element",
-        "concepts": [ { "code": "bar", "codeSystem": "http://foo.org", "displayText": "Foobar"}],
-        "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
-          {
-            "type": "object",
-            "properties": {
-              "Value": {
-                "type": "string"
-              }
-            },
-            "required": ["Value"]
+        "type": "object",
+        "properties": {
+          "Value": {
+            "type": "string"
+          },
+          "EntryType": {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
           }
+        },
+        "concepts": [
+          {
+            "code": "bar",
+            "codeSystem": "http://foo.org",
+            "displayText": "Foobar"
+          }
+        ],
+        "description": "It is a simple element",
+        "required": [
+          "Value",
+          "EntryType"
         ]
       },
       "SimpleChild": {
-        "description": "A derivative of the simple type.",
         "allOf": [
-          { "$ref": "#/definitions/Simple" },
+          {
+            "$ref": "#/definitions/Simple"
+          },
           {
             "type": "object",
             "properties": {}
           }
-        ]
-      },
-      "Coded": {
-        "description": "It is a coded element",
-        "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
-          {
-            "type": "object",
-            "properties": {
-              "Value": {
-                "type": "object",
-                "properties": {
-                  "code": { "type": "string" },
-                  "codeSystem": { "type": "string", "format": "uri" },
-                  "displayText": { "type": "string" }
-                },
-                "required": [ "code", "codeSystem" ],
-                "valueSet": {
-                  "uri": "http://standardhealthrecord.org/test/vs/Coded",
-                  "strength": "REQUIRED"
-                }
-              }
-            },
-            "required": ["Value"]
-          }
-        ]
-      },
-      "ForeignElementValue": {
-        "description": "It is an element with a foreign element value",
-        "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
-          {
-            "type": "object",
-            "properties": {
-              "Value": {
-                "$ref": "https://standardhealthrecord.org/test/shr/other/test#/definitions/Simple"
-              }
-            },
-            "required": ["Value"]
-          }
-        ]
-      },
-      "ElementValue": {
-        "description": "It is an element with an element value",
-        "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
-          {
-            "type": "object",
-            "properties": {
-              "Value": {
-                "$ref": "#/definitions/Simple"
-              }
-            },
-            "required": ["Value"]
-          }
-        ]
+        ],
+        "description": "A derivative of the simple type."
       }
-    }
+    },
+    "type": "object",
+    "anyOf": [
+      {
+        "$ref": "#/definitions/GroupDerivative"
+      }
+    ]
   },
   "https://standardhealthrecord.org/test/shr/other/test": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/other/test",
     "title": "TODO: Figure out what the title should be.",
-    "type": "object",
-    "anyOf": [
-      { "$ref": "#/definitions/Simple" }
-    ],
     "definitions": {
       "Simple": {
-        "description": "It is a simple element",
-        "concepts": [ { "code": "bar", "codeSystem": "http://foo.org", "displayText": "Foobar"}],
-        "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
-          {
-            "type": "object",
-            "properties": {
-              "Value": {
-                "type": "string"
-              }
-            },
-            "required": ["Value"]
+        "type": "object",
+        "properties": {
+          "Value": {
+            "type": "string"
+          },
+          "EntryType": {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
           }
+        },
+        "concepts": [
+          {
+            "code": "bar",
+            "codeSystem": "http://foo.org",
+            "displayText": "Foobar"
+          }
+        ],
+        "description": "It is a simple element",
+        "required": [
+          "Value",
+          "EntryType"
         ]
       }
     }

--- a/test/fixtures/TypeConstraints.schema.json
+++ b/test/fixtures/TypeConstraints.schema.json
@@ -1,4 +1,41 @@
 {
+  "https://standardhealthrecord.org/schema/cimpl/builtin": {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "https://standardhealthrecord.org/schema/cimpl/builtin",
+    "title": "CIMPL Builtin Schema",
+    "definitions": {
+      "Concept": {
+        "type": "object",
+        "properties": {
+          "coding": {
+            "type": "array",
+            "minItems": 0,
+            "items": {
+              "$ref": "#/definitions/Coding"
+            }
+          }
+        },
+        "required": [
+          "coding"
+        ]
+      },
+      "Coding": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "system": {
+            "type": "string",
+            "format": "uri"
+          },
+          "display": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
   "https://standardhealthrecord.org/test/shr/test": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
@@ -8,23 +45,7 @@
         "type": "object",
         "properties": {
           "Value": {
-            "type": "object",
-            "properties": {
-              "code": {
-                "type": "string"
-              },
-              "codeSystem": {
-                "type": "string",
-                "format": "uri"
-              },
-              "displayText": {
-                "type": "string"
-              }
-            },
-            "required": [
-              "code",
-              "codeSystem"
-            ],
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/Concept",
             "valueSet": {
               "uri": "http://standardhealthrecord.org/test/vs/Coded",
               "strength": "REQUIRED"
@@ -94,14 +115,22 @@
         },
         "concepts": [
           {
-            "code": "bar",
-            "codeSystem": "http://foo.org",
-            "displayText": "Foobar"
+            "coding": [
+              {
+                "code": "bar",
+                "system": "http://foo.org",
+                "display": "Foobar"
+              }
+            ]
           },
           {
-            "code": "far",
-            "codeSystem": "http://boo.org",
-            "displayText": "Boofar"
+            "coding": [
+              {
+                "code": "far",
+                "system": "http://boo.org",
+                "display": "Boofar"
+              }
+            ]
           }
         ],
         "description": "It is a group of elements",
@@ -155,9 +184,13 @@
         },
         "concepts": [
           {
-            "code": "bar",
-            "codeSystem": "http://foo.org",
-            "displayText": "Foobar"
+            "coding": [
+              {
+                "code": "bar",
+                "system": "http://foo.org",
+                "display": "Foobar"
+              }
+            ]
           }
         ],
         "description": "It is a simple element",
@@ -203,9 +236,13 @@
         },
         "concepts": [
           {
-            "code": "bar",
-            "codeSystem": "http://foo.org",
-            "displayText": "Foobar"
+            "coding": [
+              {
+                "code": "bar",
+                "system": "http://foo.org",
+                "display": "Foobar"
+              }
+            ]
           }
         ],
         "description": "It is a simple element",

--- a/test/fixtures/TypeConstraintsWithPath.schema.json
+++ b/test/fixtures/TypeConstraintsWithPath.schema.json
@@ -1,4 +1,41 @@
 {
+  "https://standardhealthrecord.org/schema/cimpl/builtin": {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "https://standardhealthrecord.org/schema/cimpl/builtin",
+    "title": "CIMPL Builtin Schema",
+    "definitions": {
+      "Concept": {
+        "type": "object",
+        "properties": {
+          "coding": {
+            "type": "array",
+            "minItems": 0,
+            "items": {
+              "$ref": "#/definitions/Coding"
+            }
+          }
+        },
+        "required": [
+          "coding"
+        ]
+      },
+      "Coding": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "system": {
+            "type": "string",
+            "format": "uri"
+          },
+          "display": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
   "https://standardhealthrecord.org/test/shr/test": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
@@ -105,9 +142,13 @@
         },
         "concepts": [
           {
-            "code": "bar",
-            "codeSystem": "http://foo.org",
-            "displayText": "Foobar"
+            "coding": [
+              {
+                "code": "bar",
+                "system": "http://foo.org",
+                "display": "Foobar"
+              }
+            ]
           }
         ],
         "description": "It is a simple element",

--- a/test/fixtures/TypeConstraintsWithPath.schema.json
+++ b/test/fixtures/TypeConstraintsWithPath.schema.json
@@ -3,21 +3,15 @@
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
     "title": "TODO: Figure out what the title should be.",
-    "type": "object",
-    "anyOf": [
-      { "$ref": "#/definitions/ConstrainedPath" },
-      { "$ref": "#/definitions/ConstrainedPathNoInheritance" },
-      { "$ref": "#/definitions/ElementField" },
-      { "$ref": "#/definitions/NestedField" },
-      { "$ref": "#/definitions/Simple" },
-      { "$ref": "#/definitions/SimpleChild" },
-      { "$ref": "#/definitions/TwoDeepElementField" }
-    ],
     "definitions": {
       "ConstrainedPath": {
-        "description": "It derives an element with a nested field.",
         "allOf": [
-          { "$ref": "#/definitions/NestedField" },
+          {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry"
+          },
+          {
+            "$ref": "#/definitions/NestedField"
+          },
           {
             "type": "object",
             "properties": {
@@ -25,19 +19,23 @@
                 "properties": {
                   "ElementField": {
                     "properties": {
-                      "Simple": { "$ref": "#/definitions/SimpleChild" }
+                      "Simple": {
+                        "$ref": "#/definitions/SimpleChild"
+                      }
                     }
                   }
                 }
               }
             }
           }
-        ]
+        ],
+        "description": "It derives an element with a nested field."
       },
       "ConstrainedPathNoInheritance": {
-        "description": "It has a new field with a nested constraint.",
         "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
+          {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry"
+          },
           {
             "type": "object",
             "properties": {
@@ -47,86 +45,114 @@
                     "properties": {
                       "ElementField": {
                         "properties": {
-                          "Simple": { "$ref": "#/definitions/SimpleChild" }
+                          "Simple": {
+                            "$ref": "#/definitions/SimpleChild"
+                          }
                         }
                       }
                     }
                   },
-                  { "$ref": "#/definitions/TwoDeepElementField" }
+                  {
+                    "$ref": "#/definitions/TwoDeepElementField"
+                  }
                 ]
               }
             }
           }
+        ],
+        "description": "It has a new field with a nested constraint."
+      },
+      "ElementField": {
+        "type": "object",
+        "properties": {
+          "Simple": {
+            "$ref": "#/definitions/Simple"
+          },
+          "EntryType": {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+          }
+        },
+        "description": "It is an element with a field.",
+        "required": [
+          "Simple",
+          "EntryType"
         ]
       },
       "NestedField": {
+        "type": "object",
+        "properties": {
+          "TwoDeepElementField": {
+            "$ref": "#/definitions/TwoDeepElementField"
+          },
+          "EntryType": {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+          }
+        },
         "description": "It is an element with a nested field.",
-        "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
-          {
-            "type": "object",
-            "properties": {
-              "TwoDeepElementField": {
-                "$ref": "#/definitions/TwoDeepElementField"
-              }
-            }
-          }
-        ]
-      },
-      "TwoDeepElementField": {
-        "description": "It is an element with a two-deep element field",
-        "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
-          {
-            "type": "object",
-            "properties": {
-              "ElementField": {
-                "$ref": "#/definitions/ElementField"
-              }
-            },
-            "required": ["ElementField"]
-          }
-        ]
-      },
-      "ElementField": {
-        "description": "It is an element with a field.",
-        "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
-          {
-            "type": "object",
-            "properties": {
-              "Simple": { "$ref": "#/definitions/Simple" }
-            },
-            "required": ["Simple"]
-          }
+        "required": [
+          "EntryType"
         ]
       },
       "Simple": {
-        "description": "It is a simple element",
-        "concepts": [ { "code": "bar", "codeSystem": "http://foo.org", "displayText": "Foobar"}],
-        "allOf": [
-          { "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry" },
-          {
-            "type": "object",
-            "properties": {
-              "Value": {
-                "type": "string"
-              }
-            },
-            "required": ["Value"]
+        "type": "object",
+        "properties": {
+          "Value": {
+            "type": "string"
+          },
+          "EntryType": {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
           }
+        },
+        "concepts": [
+          {
+            "code": "bar",
+            "codeSystem": "http://foo.org",
+            "displayText": "Foobar"
+          }
+        ],
+        "description": "It is a simple element",
+        "required": [
+          "Value",
+          "EntryType"
         ]
       },
       "SimpleChild": {
-        "description": "A derivative of the simple type.",
         "allOf": [
-          { "$ref": "#/definitions/Simple" },
+          {
+            "$ref": "#/definitions/Simple"
+          },
           {
             "type": "object",
             "properties": {}
           }
+        ],
+        "description": "A derivative of the simple type."
+      },
+      "TwoDeepElementField": {
+        "type": "object",
+        "properties": {
+          "ElementField": {
+            "$ref": "#/definitions/ElementField"
+          },
+          "EntryType": {
+            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+          }
+        },
+        "description": "It is an element with a two-deep element field",
+        "required": [
+          "ElementField",
+          "EntryType"
         ]
       }
-    }
+    },
+    "type": "object",
+    "anyOf": [
+      {
+        "$ref": "#/definitions/ConstrainedPath"
+      },
+      {
+        "$ref": "#/definitions/ConstrainedPathNoInheritance"
+      }
+    ]
   }
 }

--- a/test/fixtures/instances/Coded.json
+++ b/test/fixtures/instances/Coded.json
@@ -4,5 +4,5 @@
   "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/test/Coded"},
   "CreationTime": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"} },
   "LastUpdated": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"} },
-  "Value": { "code": "bar", "codeSystem": "urn:some-namespace:foo" }
+  "Value": { "coding": [{ "code": "bar", "system": "urn:some-namespace:foo" }] }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -915,17 +915,20 @@ shelljs@^0.7.5:
     interpret "^1.0.0"
     rechoir "^0.6.2"
 
-shr-expand@^5.5.2:
-  version "5.5.2"
-  resolved "https://registry.yarnpkg.com/shr-expand/-/shr-expand-5.5.2.tgz#e325327b8e1a1995229c7abb1fbef4a5347b67ff"
+shr-expand@^6.0.0-beta.1:
+  version "6.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/shr-expand/-/shr-expand-6.0.0-beta.1.tgz#2ef7ada2c5d5cc390e05216ebba88a160bb3c924"
+  integrity sha512-CQ2zOMQ3cD/8g0F89KfZGNoARzie7fEK4CfCM6Xd8RWMFAIK26gAJN5+M5yqEqghxCqt9RFvQP/WnmBL2mopgA==
 
-shr-models@^5.5.3:
-  version "5.5.3"
-  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-5.5.3.tgz#bc972ba2355bd7dd35d1169c7f17332967165c65"
+shr-models@^6.0.0-beta.1:
+  version "6.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-6.0.0-beta.1.tgz#52f6c9ff10838820c00d6c4e524b237fb95db646"
+  integrity sha512-M7Iz17rCDXDnJ+Su2FbybikNT/O2fHG50BkS+rH4ydFa/6EgLvhL89VI+o9qG+mot3DRb+gvMStn9n7SVkqkwQ==
 
-shr-test-helpers@^5.2.2:
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/shr-test-helpers/-/shr-test-helpers-5.2.2.tgz#31c18d3db71a0181cd18e74105b42881756f5834"
+shr-test-helpers@^6.0.0-beta.1:
+  version "6.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/shr-test-helpers/-/shr-test-helpers-6.0.0-beta.1.tgz#ac43b7ab786cfa398288ae553ddc5626543e9c42"
+  integrity sha512-mIh7qoo/1utxjMyGbMZlTY/EWwrkWwHe8gk+1MbqtEd0L9837+pMIHCsmYFhlkj10eKvFL8g4lDzy2ZSYAPrdQ==
   dependencies:
     fs-extra "^5.0.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -915,20 +915,20 @@ shelljs@^0.7.5:
     interpret "^1.0.0"
     rechoir "^0.6.2"
 
-shr-expand@^6.0.0-beta.1:
-  version "6.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/shr-expand/-/shr-expand-6.0.0-beta.1.tgz#2ef7ada2c5d5cc390e05216ebba88a160bb3c924"
-  integrity sha512-CQ2zOMQ3cD/8g0F89KfZGNoARzie7fEK4CfCM6Xd8RWMFAIK26gAJN5+M5yqEqghxCqt9RFvQP/WnmBL2mopgA==
+shr-expand@^6.0.0-beta.2:
+  version "6.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/shr-expand/-/shr-expand-6.0.0-beta.2.tgz#030b6d6c72071b1ca8e171863ad7466b4bd02aab"
+  integrity sha512-XBMSJcg7aeCV0OjNrARDhnYUZ0FInojpNKfjKjBb42lMP4pmEuifY/ErSzXDauJLzUZpV3BuRXQ5XueKau9p3Q==
 
-shr-models@^6.0.0-beta.1:
-  version "6.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-6.0.0-beta.1.tgz#52f6c9ff10838820c00d6c4e524b237fb95db646"
-  integrity sha512-M7Iz17rCDXDnJ+Su2FbybikNT/O2fHG50BkS+rH4ydFa/6EgLvhL89VI+o9qG+mot3DRb+gvMStn9n7SVkqkwQ==
+shr-models@^6.0.0-beta.2:
+  version "6.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-6.0.0-beta.2.tgz#8a730e43dc3e044e26758d7e7569155207901215"
+  integrity sha512-8VpMawL//uZ5dhXoNCEfVmxBAoPhPtLHdvLDwdedujaFdggqNOKwncn8KsYbJl3FXrnwWKlG8FOMRkEYw9xXBg==
 
-shr-test-helpers@^6.0.0-beta.1:
-  version "6.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/shr-test-helpers/-/shr-test-helpers-6.0.0-beta.1.tgz#ac43b7ab786cfa398288ae553ddc5626543e9c42"
-  integrity sha512-mIh7qoo/1utxjMyGbMZlTY/EWwrkWwHe8gk+1MbqtEd0L9837+pMIHCsmYFhlkj10eKvFL8g4lDzy2ZSYAPrdQ==
+shr-test-helpers@^6.0.0-beta.2:
+  version "6.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/shr-test-helpers/-/shr-test-helpers-6.0.0-beta.2.tgz#6b8e9c5b7e46c8922c3261b691bb35c2352c0d90"
+  integrity sha512-onl2ZZOHFopgQmW0p30DPURg9NltmezRKiKfnp2Uww0OgHySH3kiXgVJP8/ie3P7mvv6N7aJ+yNP9luBAJ933g==
   dependencies:
     fs-extra "^5.0.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -915,20 +915,20 @@ shelljs@^0.7.5:
     interpret "^1.0.0"
     rechoir "^0.6.2"
 
-shr-expand@^6.0.0-beta.2:
-  version "6.0.0-beta.2"
-  resolved "https://registry.yarnpkg.com/shr-expand/-/shr-expand-6.0.0-beta.2.tgz#030b6d6c72071b1ca8e171863ad7466b4bd02aab"
-  integrity sha512-XBMSJcg7aeCV0OjNrARDhnYUZ0FInojpNKfjKjBb42lMP4pmEuifY/ErSzXDauJLzUZpV3BuRXQ5XueKau9p3Q==
+shr-expand@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/shr-expand/-/shr-expand-6.0.0.tgz#a2072f971e19b9f221e012c0056ee389a78633d7"
+  integrity sha512-zzjli5uVY23J4jHnr5Cr+iLkZ7+6RsHk3kQMksBPUR4ly96NXlCRgillJ3IszbdP3dHpBuWymcrAOjyz4C/lRA==
 
-shr-models@^6.0.0-beta.2:
-  version "6.0.0-beta.2"
-  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-6.0.0-beta.2.tgz#8a730e43dc3e044e26758d7e7569155207901215"
-  integrity sha512-8VpMawL//uZ5dhXoNCEfVmxBAoPhPtLHdvLDwdedujaFdggqNOKwncn8KsYbJl3FXrnwWKlG8FOMRkEYw9xXBg==
+shr-models@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-6.0.0.tgz#6ffe6a48ae6bcf6c20e25dbfcc5b2954fca7d661"
+  integrity sha512-k8tU/YghNoFdpHxzC1ZpfpHMEMAJPZyGGAMd9QfOcCqDsETUyK9u76GuXoSlhXHjDM5CXOCeq6LmxWCQhK95iw==
 
-shr-test-helpers@^6.0.0-beta.2:
-  version "6.0.0-beta.2"
-  resolved "https://registry.yarnpkg.com/shr-test-helpers/-/shr-test-helpers-6.0.0-beta.2.tgz#6b8e9c5b7e46c8922c3261b691bb35c2352c0d90"
-  integrity sha512-onl2ZZOHFopgQmW0p30DPURg9NltmezRKiKfnp2Uww0OgHySH3kiXgVJP8/ie3P7mvv6N7aJ+yNP9luBAJ933g==
+shr-test-helpers@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/shr-test-helpers/-/shr-test-helpers-6.0.0.tgz#03cc56f2e6abe5b7f6e3c3459e6fbd3243c440f5"
+  integrity sha512-4CFQsZMM4PWBgcr+BO9yepCNKp6WMX4bBzavHqYfceAA7pA7WsMpKiAnXYUs/tFH4fZbbU7ZX/kAJcPPi4uLbQ==
   dependencies:
     fs-extra "^5.0.0"
 


### PR DESCRIPTION
Changes needed to support CIMPL6.  The two most significant changes to the model are:

* Replaced `code`, `Coding`, and `CodeableConcept` with new `concept` primitive
* Removed `RefValue` in favor of using a field's "entry-ness" to determine if it should be a reference

This included adding a new custom schema to represent `Concept`.

All unit tests should pass.  For information on running w/ CIMPL6 source see:
https://github.com/standardhealth/shr-cli/pull/207

Marking as a DRAFT PR because all versions will need to be bumped to non-beta versions upon approval.