### PR TITLE
Add SubsetConstraint

### DIFF
--- a/lib/export.js
+++ b/lib/export.js
@@ -544,7 +544,6 @@ function convertDefinition(valueDef, dataElementsSpecs, enclosingNamespace, base
         constraintDfs(node[path], currentAllOf[0].properties[path].allOf, currentAllOf);
       } else {
         currentAllOf[0].constraints = [];
-        let currentAnyOf = [];
         let includesConstraints = null;
         let includesCodeConstraints = null;
         for (const constraintInfo of node.$self) {
@@ -573,17 +572,15 @@ function convertDefinition(valueDef, dataElementsSpecs, enclosingNamespace, base
               logger.error({target1 : constraintInfo.constraintTarget.toString(), constraint1 : constraintInfo.constraint.toString() },'18009' );
             }
           } else if (constraintInfo.constraint instanceof SubsetConstraint) {
-            anyOf = [];
-            if (constraintInfo.constraintTarget instanceof ChoiceValue) {
-              for (const option of constraintInfo.constraint.subsetList) {
-                let schemaConstraint = null;
-                if (option.isPrimitive) {
-                  schemaConstraint = makePrimitiveObject(option);
-                } else {
-                  schemaConstraint = {$ref: makeRef(option, enclosingNamespace, baseSchemaURL)}
-                }
-                anyOf.push(schemaConstraint);
+            const anyOf = [];
+            for (const option of constraintInfo.constraint.subsetList) {
+              let schemaConstraint = null;
+              if (option.isPrimitive) {
+                schemaConstraint = makePrimitiveObject(option);
+              } else {
+                schemaConstraint = {$ref: makeRef(option, enclosingNamespace, baseSchemaURL)}
               }
+              anyOf.push(schemaConstraint);
             }
             currentAllOf.push({ anyOf: anyOf });
           }

--- a/lib/export.js
+++ b/lib/export.js
@@ -3,7 +3,7 @@
 // Derived from export SHR specification content as a hierarchy in JSON format by Greg Quinn
 
 const bunyan = require('bunyan');
-const {Identifier, IdentifiableValue, ChoiceValue, TBD, IncompleteValue, ValueSetConstraint, IncludesCodeConstraint, IncludesTypeConstraint, CodeConstraint, CardConstraint, TypeConstraint, INHERITED, OVERRIDDEN, BooleanConstraint, FixedValueConstraint, MODELS_INFO, PRIMITIVE_NS} = require('shr-models');
+const {Identifier, IdentifiableValue, ChoiceValue, TBD, IncompleteValue, ValueSetConstraint, IncludesCodeConstraint, IncludesTypeConstraint, CodeConstraint, CardConstraint, TypeConstraint, SubsetConstraint, INHERITED, OVERRIDDEN, BooleanConstraint, FixedValueConstraint, MODELS_INFO, PRIMITIVE_NS} = require('shr-models');
 const builtinSchema = require('./schemas/cimpl.builtin.schema.json');
 
 var rootLogger = bunyan.createLogger({name: 'shr-json-schema-export'});
@@ -544,6 +544,7 @@ function convertDefinition(valueDef, dataElementsSpecs, enclosingNamespace, base
         constraintDfs(node[path], currentAllOf[0].properties[path].allOf, currentAllOf);
       } else {
         currentAllOf[0].constraints = [];
+        let currentAnyOf = [];
         let includesConstraints = null;
         let includesCodeConstraints = null;
         for (const constraintInfo of node.$self) {
@@ -571,7 +572,22 @@ function convertDefinition(valueDef, dataElementsSpecs, enclosingNamespace, base
               //18009, 'Internal error unexpected constraint target: ${target1} for constraint ${constraint1}'A , 'Unknown' , 'errorNumber'
               logger.error({target1 : constraintInfo.constraintTarget.toString(), constraint1 : constraintInfo.constraint.toString() },'18009' );
             }
-          } else if (constraintInfo.constraint instanceof IncludesTypeConstraint) {
+          } else if (constraintInfo.constraint instanceof SubsetConstraint) {
+            anyOf = [];
+            if (constraintInfo.constraintTarget instanceof ChoiceValue) {
+              for (const option of constraintInfo.constraint.subsetList) {
+                let schemaConstraint = null;
+                if (option.isPrimitive) {
+                  schemaConstraint = makePrimitiveObject(option);
+                } else {
+                  schemaConstraint = {$ref: makeRef(option, enclosingNamespace, baseSchemaURL)}
+                }
+                anyOf.push(schemaConstraint);
+              }
+            }
+            currentAllOf.push({ anyOf: anyOf });
+          }
+           else if (constraintInfo.constraint instanceof IncludesTypeConstraint) {
             if (!includesConstraints) {
               includesConstraints = {refs: [], types: [], min: 0, max: 0};
             }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "eslint": "^3.6.1",
     "mocha": "^3.2.0",
     "shr-expand": "^6.5.0",
-    "shr-models": "^6.6.0",
+    "shr-models": "standardhealth/shr-models#add-subset-constraint",
     "shr-test-helpers": "^6.0.0"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -920,10 +920,9 @@ shr-expand@^6.5.0:
   resolved "https://registry.yarnpkg.com/shr-expand/-/shr-expand-6.5.0.tgz#22663c477af76ea24de778973abe2c9c4ae652bb"
   integrity sha512-PPIBy5a1SDrCKM8gEidvXm5NiPBzRybdSD4dwcBI4GqGkrPsXRsgWuG8KhPNU1fi5ylFP4xrhrN86Uzml6hXAQ==
 
-shr-models@^6.6.0:
+shr-models@standardhealth/shr-models#add-subset-constraint:
   version "6.6.0"
-  resolved "https://registry.yarnpkg.com/shr-models/-/shr-models-6.6.0.tgz#5d58d01d58f1adf500c8129b1510f69cccce1dbc"
-  integrity sha512-OMnpOdJN61Gr9abzveIZrfxQQoi2CLHbeFOfzgcahiX1ERZ+tQOqxLFvc0vrB3js9yQewmCZVH9w11pHSp6PTQ==
+  resolved "https://codeload.github.com/standardhealth/shr-models/tar.gz/d04a6807ca61eae332e29d92477ca4d17c67c4a2"
 
 shr-test-helpers@^6.0.0:
   version "6.0.0"


### PR DESCRIPTION
This adds support for exporting `SubsetConstraint`s to json-schema.
This PR is 5/7. These PRs impact:
* `shr-grammar` https://github.com/standardhealth/shr-grammar/pull/46
* `shr-text-import` https://github.com/standardhealth/shr-text-import/pull/108
* `shr-models` https://github.com/standardhealth/shr-models/pull/47
* `shr-expand` https://github.com/standardhealth/shr-expand/pull/48
* `shr-fhir-export` https://github.com/standardhealth/shr-fhir-export/pull/161
* `shr-json-schema-export`
* `shr-json-javadoc` https://github.com/standardhealth/shr-json-javadoc/pull/29