### PR TITLE
Switch to built-in type for Entry's properties

### DIFF
--- a/lib/export.js
+++ b/lib/export.js
@@ -69,12 +69,12 @@ function namespaceToSchema(ns, dataElementsSpecs, baseSchemaURL, baseTypeURL) {
     title: 'TODO: Figure out what the title should be.',
     definitions: {}
   };
-  const entryRef = makeRef(new Identifier('shr.base', 'Entry'), ns, baseSchemaURL);
+  const entryRef = 'https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/Entry';
   if (ns.description) {
     schema.description = ns.description;
   }
   const nonEntryEntryTypeField = {
-    $ref: makeRef(new Identifier('shr.base', 'EntryType'), ns, baseSchemaURL)
+    $ref: 'https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType'
   };
 
   const defs = dataElements.sort(function(l,r) {return l.identifier.name.localeCompare(r.identifier.name);});
@@ -174,10 +174,6 @@ function namespaceToSchema(ns, dataElementsSpecs, baseSchemaURL, baseTypeURL) {
             continue;
           }
 
-          if (field.identifier.fqn === 'shr.base.EntryType') {
-            needsEntryType = false;
-          }
-
           schemaDef.properties[field.identifier.name] = value;
           if (required) {
             requiredProperties.push(field.identifier.name);
@@ -212,9 +208,7 @@ function namespaceToSchema(ns, dataElementsSpecs, baseSchemaURL, baseTypeURL) {
       }
       if (needsEntryType) {
         schemaDef.properties['EntryType'] = nonEntryEntryTypeField;
-        if (def.identifier.fqn !== 'shr.base.EntryType') {
-          requiredProperties.push('EntryType');
-        }
+        requiredProperties.push('EntryType');
       }
 
       if (requiredProperties.length) {
@@ -1055,18 +1049,15 @@ function extractUnnormalizedConstraintPath(constraint, valueDef, dataElementSpec
 }
 
 function makeExpandedEntryDefinitions(enclosingNamespace, baseSchemaURL) {
-  const properties = {};
-  for (const name of ['ShrId', 'EntryId', 'EntryType', 'FocalSubject', 'SubjectIsThirdPartyFlag', 'Narrative', 'Informant', 'Author', 'AssociatedEncounter', 'OriginalCreationDate', 'LastUpdateDate', 'Language']) {
-    properties[name] = { $ref: makeRef(new Identifier('shr.base', name), enclosingNamespace, baseSchemaURL) };
-  }
-  properties.Version = { $ref: makeRef(new Identifier('shr.core', 'Version'), enclosingNamespace, baseSchemaURL) };
+  const properties = {
+    ShrId: { $ref: 'https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/ShrId' },
+    EntryId: { $ref: 'https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryId' },
+    EntryType: { $ref: 'https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType' }
+  };
   return { properties, required: [
-    'shr.base.ShrId',
-    'shr.base.EntryId',
-    'shr.base.EntryType',
-    'shr.base.FocalSubject',
-    'shr.base.OriginalCreationDate',
-    'shr.base.LastUpdateDate'
+    'ShrId',
+    'EntryId',
+    'EntryType'
   ]};
 }
 

--- a/lib/export.js
+++ b/lib/export.js
@@ -17,7 +17,7 @@ function setLogger(bunyanLogger) {
  * Converts a group of specifications into JSON Schema.
  * @param {Specifications} expSpecifications - a fully expanded Specifications object.
  * @param {string} baseSchemaURL - the root URL for the schema identifier.
- * @param {string} baseTypeURL - the root URL for the EntryType field.
+ * @param {string} baseTypeURL - the root URL for the entryType field.
  * @param {boolean=} flat - if true then the generated schema will not be hierarchical. Defaults to false.
  * @return {Object.<string, Object>} A mapping of schema ids to JSON Schema definitions.
  */
@@ -57,7 +57,7 @@ function exportToJSONSchema(expSpecifications, baseSchemaURL, baseTypeURL, flat 
  * @param {Namespace} ns - the namespace of the schema.
  * @param {DataElementSpecifications} dataElementsSpecs - the elements in the namespace.
  * @param {string} baseSchemaURL - the root URL for the schema identifier.
- * @param {string} baseTypeURL - the root URL for the EntryType field.
+ * @param {string} baseTypeURL - the root URL for the entryType field.
  * @return {{schemaId: string, schema: Object}} The schema id and the JSON Schema definition.
  */
 function namespaceToSchema(ns, dataElementsSpecs, baseSchemaURL, baseTypeURL) {
@@ -74,7 +74,8 @@ function namespaceToSchema(ns, dataElementsSpecs, baseSchemaURL, baseTypeURL) {
     schema.description = ns.description;
   }
   const nonEntryEntryTypeField = {
-    $ref: 'https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType'
+    type: 'string',
+    format: 'uri'
   };
 
   const defs = dataElements.sort(function(l,r) {return l.identifier.name.localeCompare(r.identifier.name);});
@@ -207,8 +208,8 @@ function namespaceToSchema(ns, dataElementsSpecs, baseSchemaURL, baseTypeURL) {
         wholeDef.description = descriptionList.join('\n');
       }
       if (needsEntryType) {
-        schemaDef.properties['EntryType'] = nonEntryEntryTypeField;
-        requiredProperties.push('EntryType');
+        schemaDef.properties['entryType'] = nonEntryEntryTypeField;
+        requiredProperties.push('entryType');
       }
 
       if (requiredProperties.length) {
@@ -236,7 +237,7 @@ function namespaceToSchema(ns, dataElementsSpecs, baseSchemaURL, baseTypeURL) {
  * @param {Namespace} ns - the namespace of the schema.
  * @param {DataElementSpecifications} dataElementsSpecs - the elements in the namespace.
  * @param {string} baseSchemaURL - the root URL for the schema identifier.
- * @param {string} baseTypeURL - the root URL for the EntryType field.
+ * @param {string} baseTypeURL - the root URL for the entryType field.
  * @return {{schemaId: string, schema: Object}} The schema id and the JSON Schema definition.
  */
 function flatNamespaceToSchema(ns, dataElementsSpecs, baseSchemaURL, baseTypeURL) {
@@ -428,7 +429,7 @@ function convertDefinition(valueDef, dataElementsSpecs, enclosingNamespace, base
       }
     }
   } else if (isRef(valueDef, dataElementsSpecs)) {
-    // TODO: What should the value of EntryType be? The schema URL may not be portable across data types.
+    // TODO: What should the value of entryType be? The schema URL may not be portable across data types.
     makeShrRefObject([valueDef], baseTypeURL, value);
   } else if (valueDef instanceof IdentifiableValue) {
     const id = valueDef.effectiveIdentifier;
@@ -604,7 +605,7 @@ function convertDefinition(valueDef, dataElementsSpecs, enclosingNamespace, base
               strength: constraintInfo.constraint.bindingStrength
             };
           } else if (constraintInfo.constraint instanceof CodeConstraint) {
-            // Maybe TODO: For entry elements this can have some level of enforcement by ANDing the exact contents of the EntryType field with an enum for this value/field.
+            // Maybe TODO: For entry elements this can have some level of enforcement by ANDing the exact contents of the entryType field with an enum for this value/field.
             if (currentAllOf[0].code) {
               //18011, Multiple code constraints found on a single element ${element1} '  ,  'Unknown' , 'errorNumber'
               logger.error({element1 : constraintInfo.constraint },'18011' );
@@ -1050,14 +1051,14 @@ function extractUnnormalizedConstraintPath(constraint, valueDef, dataElementSpec
 
 function makeExpandedEntryDefinitions(enclosingNamespace, baseSchemaURL) {
   const properties = {
-    ShrId: { $ref: 'https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/ShrId' },
-    EntryId: { $ref: 'https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryId' },
-    EntryType: { $ref: 'https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType' }
+    shrId: { type: 'string' },
+    entryId: { type: 'string' },
+    entryType: { type: 'string', format: 'uri' }
   };
   return { properties, required: [
-    'ShrId',
-    'EntryId',
-    'EntryType'
+    'shrId',
+    'entryId',
+    'entryType'
   ]};
 }
 

--- a/lib/schemas/cimpl.builtin.schema.json
+++ b/lib/schemas/cimpl.builtin.schema.json
@@ -36,65 +36,18 @@
     "Entry": {
       "type": "object",
       "properties": {
-        "ShrId": {
-          "$ref": "#/definitions/ShrId"
+        "shrId": {
+          "type": "string"
         },
-        "EntryId": {
-          "$ref": "#/definitions/EntryId"
+        "entryId": {
+          "type": "string"
         },
-        "EntryType": {
-          "$ref": "#/definitions/EntryType"
+        "entryType": {
+          "type": "string",
+          "format": "uri"
         }
       },
       "description": "An entry in a health record."
-    },
-    "EntryId": {
-      "type": "object",
-      "properties": {
-        "Value": {
-          "type": "string"
-        },
-        "EntryType": {
-          "$ref": "#/definitions/EntryType"
-        }
-      },
-      "description": "A persistent, permanent identifier for an entry in a health record, unique within the scope of the health record.",
-      "required": [
-        "Value",
-        "EntryType"
-      ]
-    },
-    "EntryType": {
-      "type": "object",
-      "properties": {
-        "Value": {
-          "type": "string",
-          "format": "uri"
-        },
-        "EntryType": {
-          "$ref": "#/definitions/EntryType"
-        }
-      },
-      "description": "The class of the item, as a URI.",
-      "required": [
-        "Value"
-      ]
-    },
-    "ShrId": {
-      "type": "object",
-      "properties": {
-        "Value": {
-          "type": "string"
-        },
-        "EntryType": {
-          "$ref": "#/definitions/EntryType"
-        }
-      },
-      "description": "A unique, persistent, permanent identifier for the overall health record belonging to the Patient.",
-      "required": [
-        "Value",
-        "EntryType"
-      ]
     }
   }
 }

--- a/lib/schemas/cimpl.builtin.schema.json
+++ b/lib/schemas/cimpl.builtin.schema.json
@@ -32,6 +32,69 @@
           "type": "string"
         }
       }
+    },
+    "Entry": {
+      "type": "object",
+      "properties": {
+        "ShrId": {
+          "$ref": "#/definitions/ShrId"
+        },
+        "EntryId": {
+          "$ref": "#/definitions/EntryId"
+        },
+        "EntryType": {
+          "$ref": "#/definitions/EntryType"
+        }
+      },
+      "description": "An entry in a health record."
+    },
+    "EntryId": {
+      "type": "object",
+      "properties": {
+        "Value": {
+          "type": "string"
+        },
+        "EntryType": {
+          "$ref": "#/definitions/EntryType"
+        }
+      },
+      "description": "A persistent, permanent identifier for an entry in a health record, unique within the scope of the health record.",
+      "required": [
+        "Value",
+        "EntryType"
+      ]
+    },
+    "EntryType": {
+      "type": "object",
+      "properties": {
+        "Value": {
+          "type": "string",
+          "format": "uri"
+        },
+        "EntryType": {
+          "$ref": "#/definitions/EntryType"
+        }
+      },
+      "description": "The class of the item, as a URI.",
+      "required": [
+        "Value"
+      ]
+    },
+    "ShrId": {
+      "type": "object",
+      "properties": {
+        "Value": {
+          "type": "string"
+        },
+        "EntryType": {
+          "$ref": "#/definitions/EntryType"
+        }
+      },
+      "description": "A unique, persistent, permanent identifier for the overall health record belonging to the Patient.",
+      "required": [
+        "Value",
+        "EntryType"
+      ]
     }
   }
 }

--- a/test/fixtures/AbstractAndPlainGroup.schema.json
+++ b/test/fixtures/AbstractAndPlainGroup.schema.json
@@ -45,8 +45,9 @@
           "Value": {
             "type": "string"
           },
-          "EntryType": {
-            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
+          "entryType": {
+            "type": "string",
+            "format": "uri"
           }
         },
         "concepts": [
@@ -63,7 +64,7 @@
         "description": "It is not an entry element",
         "required": [
           "Value",
-          "EntryType"
+          "entryType"
         ]
       },
       "Simple": {
@@ -72,8 +73,9 @@
           "Value": {
             "type": "string"
           },
-          "EntryType": {
-            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
+          "entryType": {
+            "type": "string",
+            "format": "uri"
           }
         },
         "concepts": [
@@ -90,7 +92,7 @@
         "description": "It is a simple element",
         "required": [
           "Value",
-          "EntryType"
+          "entryType"
         ]
       }
     }

--- a/test/fixtures/AbstractAndPlainGroup.schema.json
+++ b/test/fixtures/AbstractAndPlainGroup.schema.json
@@ -1,41 +1,5 @@
 {
-  "https://standardhealthrecord.org/schema/cimpl/builtin": {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "https://standardhealthrecord.org/schema/cimpl/builtin",
-    "title": "CIMPL Builtin Schema",
-    "definitions": {
-      "Concept": {
-        "type": "object",
-        "properties": {
-          "coding": {
-            "type": "array",
-            "minItems": 0,
-            "items": {
-              "$ref": "#/definitions/Coding"
-            }
-          }
-        },
-        "required": [
-          "coding"
-        ]
-      },
-      "Coding": {
-        "type": "object",
-        "properties": {
-          "code": {
-            "type": "string"
-          },
-          "system": {
-            "type": "string",
-            "format": "uri"
-          },
-          "display": {
-            "type": "string"
-          }
-        }
-      }
-    }
-  },
+  "https://standardhealthrecord.org/schema/cimpl/builtin": "inserted in test setup",
   "https://standardhealthrecord.org/test/shr/test": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
@@ -44,7 +8,7 @@
       "AbstractAndPlainGroup": {
         "allOf": [
           {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/Entry"
           },
           {
             "type": "object",
@@ -82,7 +46,7 @@
             "type": "string"
           },
           "EntryType": {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
           }
         },
         "concepts": [
@@ -109,7 +73,7 @@
             "type": "string"
           },
           "EntryType": {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
           }
         },
         "concepts": [

--- a/test/fixtures/BooleanAndCodeConstraints.schema.json
+++ b/test/fixtures/BooleanAndCodeConstraints.schema.json
@@ -11,13 +11,14 @@
           "Value": {
             "type": "boolean"
           },
-          "EntryType": {
-            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
+          "entryType": {
+            "type": "string",
+            "format": "uri"
           }
         },
         "description": "A boolean element.",
         "required": [
-          "EntryType"
+          "entryType"
         ]
       },
       "BooleanAndCodeConstraints": {
@@ -88,14 +89,15 @@
               "strength": "REQUIRED"
             }
           },
-          "EntryType": {
-            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
+          "entryType": {
+            "type": "string",
+            "format": "uri"
           }
         },
         "description": "It is a coded element",
         "required": [
           "Value",
-          "EntryType"
+          "entryType"
         ]
       },
       "ElementValue": {
@@ -104,14 +106,15 @@
           "Value": {
             "$ref": "#/definitions/Simple"
           },
-          "EntryType": {
-            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
+          "entryType": {
+            "type": "string",
+            "format": "uri"
           }
         },
         "description": "It is an element with an element value",
         "required": [
           "Value",
-          "EntryType"
+          "entryType"
         ]
       },
       "ForeignElementValue": {
@@ -120,14 +123,15 @@
           "Value": {
             "$ref": "https://standardhealthrecord.org/test/shr/other/test#/definitions/Simple"
           },
-          "EntryType": {
-            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
+          "entryType": {
+            "type": "string",
+            "format": "uri"
           }
         },
         "description": "It is an element with a foreign element value",
         "required": [
           "Value",
-          "EntryType"
+          "entryType"
         ]
       },
       "Group": {
@@ -146,8 +150,9 @@
               "$ref": "#/definitions/ElementValue"
             }
           },
-          "EntryType": {
-            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
+          "entryType": {
+            "type": "string",
+            "format": "uri"
           }
         },
         "concepts": [
@@ -173,7 +178,7 @@
         "description": "It is a group of elements",
         "required": [
           "Simple",
-          "EntryType"
+          "entryType"
         ]
       },
       "Simple": {
@@ -182,8 +187,9 @@
           "Value": {
             "type": "string"
           },
-          "EntryType": {
-            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
+          "entryType": {
+            "type": "string",
+            "format": "uri"
           }
         },
         "concepts": [
@@ -200,7 +206,7 @@
         "description": "It is a simple element",
         "required": [
           "Value",
-          "EntryType"
+          "entryType"
         ]
       }
     },
@@ -222,8 +228,9 @@
           "Value": {
             "type": "string"
           },
-          "EntryType": {
-            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
+          "entryType": {
+            "type": "string",
+            "format": "uri"
           }
         },
         "concepts": [
@@ -240,7 +247,7 @@
         "description": "It is a simple element",
         "required": [
           "Value",
-          "EntryType"
+          "entryType"
         ]
       }
     }

--- a/test/fixtures/BooleanAndCodeConstraints.schema.json
+++ b/test/fixtures/BooleanAndCodeConstraints.schema.json
@@ -1,41 +1,5 @@
 {
-  "https://standardhealthrecord.org/schema/cimpl/builtin": {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "https://standardhealthrecord.org/schema/cimpl/builtin",
-    "title": "CIMPL Builtin Schema",
-    "definitions": {
-      "Concept": {
-        "type": "object",
-        "properties": {
-          "coding": {
-            "type": "array",
-            "minItems": 0,
-            "items": {
-              "$ref": "#/definitions/Coding"
-            }
-          }
-        },
-        "required": [
-          "coding"
-        ]
-      },
-      "Coding": {
-        "type": "object",
-        "properties": {
-          "code": {
-            "type": "string"
-          },
-          "system": {
-            "type": "string",
-            "format": "uri"
-          },
-          "display": {
-            "type": "string"
-          }
-        }
-      }
-    }
-  },
+  "https://standardhealthrecord.org/schema/cimpl/builtin": "inserted in test setup",
   "https://standardhealthrecord.org/test/shr/test": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
@@ -48,7 +12,7 @@
             "type": "boolean"
           },
           "EntryType": {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
           }
         },
         "description": "A boolean element.",
@@ -59,7 +23,7 @@
       "BooleanAndCodeConstraints": {
         "allOf": [
           {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/Entry"
           },
           {
             "$ref": "#/definitions/Group"
@@ -125,7 +89,7 @@
             }
           },
           "EntryType": {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
           }
         },
         "description": "It is a coded element",
@@ -141,7 +105,7 @@
             "$ref": "#/definitions/Simple"
           },
           "EntryType": {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
           }
         },
         "description": "It is an element with an element value",
@@ -157,7 +121,7 @@
             "$ref": "https://standardhealthrecord.org/test/shr/other/test#/definitions/Simple"
           },
           "EntryType": {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
           }
         },
         "description": "It is an element with a foreign element value",
@@ -183,7 +147,7 @@
             }
           },
           "EntryType": {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
           }
         },
         "concepts": [
@@ -219,7 +183,7 @@
             "type": "string"
           },
           "EntryType": {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
           }
         },
         "concepts": [
@@ -259,7 +223,7 @@
             "type": "string"
           },
           "EntryType": {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
           }
         },
         "concepts": [

--- a/test/fixtures/Choice.schema.json
+++ b/test/fixtures/Choice.schema.json
@@ -1,41 +1,5 @@
 {
-  "https://standardhealthrecord.org/schema/cimpl/builtin": {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "https://standardhealthrecord.org/schema/cimpl/builtin",
-    "title": "CIMPL Builtin Schema",
-    "definitions": {
-      "Concept": {
-        "type": "object",
-        "properties": {
-          "coding": {
-            "type": "array",
-            "minItems": 0,
-            "items": {
-              "$ref": "#/definitions/Coding"
-            }
-          }
-        },
-        "required": [
-          "coding"
-        ]
-      },
-      "Coding": {
-        "type": "object",
-        "properties": {
-          "code": {
-            "type": "string"
-          },
-          "system": {
-            "type": "string",
-            "format": "uri"
-          },
-          "display": {
-            "type": "string"
-          }
-        }
-      }
-    }
-  },
+  "https://standardhealthrecord.org/schema/cimpl/builtin": "inserted in test setup",
   "https://standardhealthrecord.org/test/shr/test": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
@@ -44,7 +8,7 @@
       "Choice": {
         "allOf": [
           {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/Entry"
           },
           {
             "type": "object",
@@ -85,7 +49,7 @@
             }
           },
           "EntryType": {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
           }
         },
         "description": "It is a coded element",

--- a/test/fixtures/Choice.schema.json
+++ b/test/fixtures/Choice.schema.json
@@ -48,14 +48,15 @@
               "strength": "REQUIRED"
             }
           },
-          "EntryType": {
-            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
+          "entryType": {
+            "type": "string",
+            "format": "uri"
           }
         },
         "description": "It is a coded element",
         "required": [
           "Value",
-          "EntryType"
+          "entryType"
         ]
       }
     },

--- a/test/fixtures/ChoiceOfChoice.schema.json
+++ b/test/fixtures/ChoiceOfChoice.schema.json
@@ -1,41 +1,5 @@
 {
-  "https://standardhealthrecord.org/schema/cimpl/builtin": {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "https://standardhealthrecord.org/schema/cimpl/builtin",
-    "title": "CIMPL Builtin Schema",
-    "definitions": {
-      "Concept": {
-        "type": "object",
-        "properties": {
-          "coding": {
-            "type": "array",
-            "minItems": 0,
-            "items": {
-              "$ref": "#/definitions/Coding"
-            }
-          }
-        },
-        "required": [
-          "coding"
-        ]
-      },
-      "Coding": {
-        "type": "object",
-        "properties": {
-          "code": {
-            "type": "string"
-          },
-          "system": {
-            "type": "string",
-            "format": "uri"
-          },
-          "display": {
-            "type": "string"
-          }
-        }
-      }
-    }
-  },
+  "https://standardhealthrecord.org/schema/cimpl/builtin": "inserted in test setup",
   "https://standardhealthrecord.org/test/shr/test": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
@@ -44,7 +8,7 @@
       "ChoiceOfChoice": {
         "allOf": [
           {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/Entry"
           },
           {
             "type": "object",

--- a/test/fixtures/ChoiceValueSetConstraint.schema.json
+++ b/test/fixtures/ChoiceValueSetConstraint.schema.json
@@ -1,41 +1,5 @@
 {
-  "https://standardhealthrecord.org/schema/cimpl/builtin": {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "https://standardhealthrecord.org/schema/cimpl/builtin",
-    "title": "CIMPL Builtin Schema",
-    "definitions": {
-      "Concept": {
-        "type": "object",
-        "properties": {
-          "coding": {
-            "type": "array",
-            "minItems": 0,
-            "items": {
-              "$ref": "#/definitions/Coding"
-            }
-          }
-        },
-        "required": [
-          "coding"
-        ]
-      },
-      "Coding": {
-        "type": "object",
-        "properties": {
-          "code": {
-            "type": "string"
-          },
-          "system": {
-            "type": "string",
-            "format": "uri"
-          },
-          "display": {
-            "type": "string"
-          }
-        }
-      }
-    }
-  },
+  "https://standardhealthrecord.org/schema/cimpl/builtin": "inserted in test setup",
   "https://standardhealthrecord.org/test/shr/test": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
@@ -44,7 +8,7 @@
       "ChoiceValueSetConstraint": {
         "allOf": [
           {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/Entry"
           },
           {
             "type": "object",
@@ -82,7 +46,7 @@
             }
           },
           "EntryType": {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
           }
         },
         "description": "It is a coded element",
@@ -105,7 +69,7 @@
             ]
           },
           "EntryType": {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
           }
         },
         "description": "An element with a choice of code fields.",

--- a/test/fixtures/ChoiceValueSetConstraint.schema.json
+++ b/test/fixtures/ChoiceValueSetConstraint.schema.json
@@ -45,14 +45,15 @@
               "strength": "REQUIRED"
             }
           },
-          "EntryType": {
-            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
+          "entryType": {
+            "type": "string",
+            "format": "uri"
           }
         },
         "description": "It is a coded element",
         "required": [
           "Value",
-          "EntryType"
+          "entryType"
         ]
       },
       "CodedChoice": {
@@ -68,13 +69,14 @@
               }
             ]
           },
-          "EntryType": {
-            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
+          "entryType": {
+            "type": "string",
+            "format": "uri"
           }
         },
         "description": "An element with a choice of code fields.",
         "required": [
-          "EntryType"
+          "entryType"
         ]
       }
     },

--- a/test/fixtures/Coded.schema.json
+++ b/test/fixtures/Coded.schema.json
@@ -1,41 +1,5 @@
 {
-  "https://standardhealthrecord.org/schema/cimpl/builtin": {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "https://standardhealthrecord.org/schema/cimpl/builtin",
-    "title": "CIMPL Builtin Schema",
-    "definitions": {
-      "Concept": {
-        "type": "object",
-        "properties": {
-          "coding": {
-            "type": "array",
-            "minItems": 0,
-            "items": {
-              "$ref": "#/definitions/Coding"
-            }
-          }
-        },
-        "required": [
-          "coding"
-        ]
-      },
-      "Coding": {
-        "type": "object",
-        "properties": {
-          "code": {
-            "type": "string"
-          },
-          "system": {
-            "type": "string",
-            "format": "uri"
-          },
-          "display": {
-            "type": "string"
-          }
-        }
-      }
-    }
-  },
+  "https://standardhealthrecord.org/schema/cimpl/builtin": "inserted in test setup",
   "https://standardhealthrecord.org/test/shr/test": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
@@ -44,7 +8,7 @@
       "Coded": {
         "allOf": [
           {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/Entry"
           },
           {
             "type": "object",

--- a/test/fixtures/ElementValue.schema.json
+++ b/test/fixtures/ElementValue.schema.json
@@ -30,8 +30,9 @@
           "Value": {
             "type": "string"
           },
-          "EntryType": {
-            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
+          "entryType": {
+            "type": "string",
+            "format": "uri"
           }
         },
         "concepts": [
@@ -48,7 +49,7 @@
         "description": "It is a simple element",
         "required": [
           "Value",
-          "EntryType"
+          "entryType"
         ]
       }
     },

--- a/test/fixtures/ElementValue.schema.json
+++ b/test/fixtures/ElementValue.schema.json
@@ -1,41 +1,5 @@
 {
-  "https://standardhealthrecord.org/schema/cimpl/builtin": {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "https://standardhealthrecord.org/schema/cimpl/builtin",
-    "title": "CIMPL Builtin Schema",
-    "definitions": {
-      "Concept": {
-        "type": "object",
-        "properties": {
-          "coding": {
-            "type": "array",
-            "minItems": 0,
-            "items": {
-              "$ref": "#/definitions/Coding"
-            }
-          }
-        },
-        "required": [
-          "coding"
-        ]
-      },
-      "Coding": {
-        "type": "object",
-        "properties": {
-          "code": {
-            "type": "string"
-          },
-          "system": {
-            "type": "string",
-            "format": "uri"
-          },
-          "display": {
-            "type": "string"
-          }
-        }
-      }
-    }
-  },
+  "https://standardhealthrecord.org/schema/cimpl/builtin": "inserted in test setup",
   "https://standardhealthrecord.org/test/shr/test": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
@@ -44,7 +8,7 @@
       "ElementValue": {
         "allOf": [
           {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/Entry"
           },
           {
             "type": "object",
@@ -67,7 +31,7 @@
             "type": "string"
           },
           "EntryType": {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
           }
         },
         "concepts": [

--- a/test/fixtures/ForeignElementValue.schema.json
+++ b/test/fixtures/ForeignElementValue.schema.json
@@ -1,41 +1,5 @@
 {
-  "https://standardhealthrecord.org/schema/cimpl/builtin": {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "https://standardhealthrecord.org/schema/cimpl/builtin",
-    "title": "CIMPL Builtin Schema",
-    "definitions": {
-      "Concept": {
-        "type": "object",
-        "properties": {
-          "coding": {
-            "type": "array",
-            "minItems": 0,
-            "items": {
-              "$ref": "#/definitions/Coding"
-            }
-          }
-        },
-        "required": [
-          "coding"
-        ]
-      },
-      "Coding": {
-        "type": "object",
-        "properties": {
-          "code": {
-            "type": "string"
-          },
-          "system": {
-            "type": "string",
-            "format": "uri"
-          },
-          "display": {
-            "type": "string"
-          }
-        }
-      }
-    }
-  },
+  "https://standardhealthrecord.org/schema/cimpl/builtin": "inserted in test setup",
   "https://standardhealthrecord.org/test/shr/test": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
@@ -44,7 +8,7 @@
       "ForeignElementValue": {
         "allOf": [
           {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/Entry"
           },
           {
             "type": "object",
@@ -80,7 +44,7 @@
             "type": "string"
           },
           "EntryType": {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
           }
         },
         "concepts": [

--- a/test/fixtures/ForeignElementValue.schema.json
+++ b/test/fixtures/ForeignElementValue.schema.json
@@ -43,8 +43,9 @@
           "Value": {
             "type": "string"
           },
-          "EntryType": {
-            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
+          "entryType": {
+            "type": "string",
+            "format": "uri"
           }
         },
         "concepts": [
@@ -61,7 +62,7 @@
         "description": "It is a simple element",
         "required": [
           "Value",
-          "EntryType"
+          "entryType"
         ]
       }
     }

--- a/test/fixtures/ForeignSimple.schema.json
+++ b/test/fixtures/ForeignSimple.schema.json
@@ -1,41 +1,5 @@
 {
-  "https://standardhealthrecord.org/schema/cimpl/builtin": {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "https://standardhealthrecord.org/schema/cimpl/builtin",
-    "title": "CIMPL Builtin Schema",
-    "definitions": {
-      "Concept": {
-        "type": "object",
-        "properties": {
-          "coding": {
-            "type": "array",
-            "minItems": 0,
-            "items": {
-              "$ref": "#/definitions/Coding"
-            }
-          }
-        },
-        "required": [
-          "coding"
-        ]
-      },
-      "Coding": {
-        "type": "object",
-        "properties": {
-          "code": {
-            "type": "string"
-          },
-          "system": {
-            "type": "string",
-            "format": "uri"
-          },
-          "display": {
-            "type": "string"
-          }
-        }
-      }
-    }
-  },
+  "https://standardhealthrecord.org/schema/cimpl/builtin": "inserted in test setup",
   "https://standardhealthrecord.org/test/shr/other/test": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/other/test",
@@ -44,7 +8,7 @@
       "Simple": {
         "allOf": [
           {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/Entry"
           },
           {
             "type": "object",

--- a/test/fixtures/Group.schema.json
+++ b/test/fixtures/Group.schema.json
@@ -1,41 +1,5 @@
 {
-  "https://standardhealthrecord.org/schema/cimpl/builtin": {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "https://standardhealthrecord.org/schema/cimpl/builtin",
-    "title": "CIMPL Builtin Schema",
-    "definitions": {
-      "Concept": {
-        "type": "object",
-        "properties": {
-          "coding": {
-            "type": "array",
-            "minItems": 0,
-            "items": {
-              "$ref": "#/definitions/Coding"
-            }
-          }
-        },
-        "required": [
-          "coding"
-        ]
-      },
-      "Coding": {
-        "type": "object",
-        "properties": {
-          "code": {
-            "type": "string"
-          },
-          "system": {
-            "type": "string",
-            "format": "uri"
-          },
-          "display": {
-            "type": "string"
-          }
-        }
-      }
-    }
-  },
+  "https://standardhealthrecord.org/schema/cimpl/builtin": "inserted in test setup",
   "https://standardhealthrecord.org/test/shr/test": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
@@ -52,7 +16,7 @@
             }
           },
           "EntryType": {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
           }
         },
         "description": "It is a coded element",
@@ -68,7 +32,7 @@
             "$ref": "#/definitions/Simple"
           },
           "EntryType": {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
           }
         },
         "description": "It is an element with an element value",
@@ -84,7 +48,7 @@
             "$ref": "https://standardhealthrecord.org/test/shr/other/test#/definitions/Simple"
           },
           "EntryType": {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
           }
         },
         "description": "It is an element with a foreign element value",
@@ -96,7 +60,7 @@
       "Group": {
         "allOf": [
           {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/Entry"
           },
           {
             "type": "object",
@@ -149,7 +113,7 @@
             "type": "string"
           },
           "EntryType": {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
           }
         },
         "concepts": [
@@ -189,7 +153,7 @@
             "type": "string"
           },
           "EntryType": {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
           }
         },
         "concepts": [

--- a/test/fixtures/Group.schema.json
+++ b/test/fixtures/Group.schema.json
@@ -15,14 +15,15 @@
               "strength": "REQUIRED"
             }
           },
-          "EntryType": {
-            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
+          "entryType": {
+            "type": "string",
+            "format": "uri"
           }
         },
         "description": "It is a coded element",
         "required": [
           "Value",
-          "EntryType"
+          "entryType"
         ]
       },
       "ElementValue": {
@@ -31,14 +32,15 @@
           "Value": {
             "$ref": "#/definitions/Simple"
           },
-          "EntryType": {
-            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
+          "entryType": {
+            "type": "string",
+            "format": "uri"
           }
         },
         "description": "It is an element with an element value",
         "required": [
           "Value",
-          "EntryType"
+          "entryType"
         ]
       },
       "ForeignElementValue": {
@@ -47,14 +49,15 @@
           "Value": {
             "$ref": "https://standardhealthrecord.org/test/shr/other/test#/definitions/Simple"
           },
-          "EntryType": {
-            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
+          "entryType": {
+            "type": "string",
+            "format": "uri"
           }
         },
         "description": "It is an element with a foreign element value",
         "required": [
           "Value",
-          "EntryType"
+          "entryType"
         ]
       },
       "Group": {
@@ -112,8 +115,9 @@
           "Value": {
             "type": "string"
           },
-          "EntryType": {
-            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
+          "entryType": {
+            "type": "string",
+            "format": "uri"
           }
         },
         "concepts": [
@@ -130,7 +134,7 @@
         "description": "It is a simple element",
         "required": [
           "Value",
-          "EntryType"
+          "entryType"
         ]
       }
     },
@@ -152,8 +156,9 @@
           "Value": {
             "type": "string"
           },
-          "EntryType": {
-            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
+          "entryType": {
+            "type": "string",
+            "format": "uri"
           }
         },
         "concepts": [
@@ -170,7 +175,7 @@
         "description": "It is a simple element",
         "required": [
           "Value",
-          "EntryType"
+          "entryType"
         ]
       }
     }

--- a/test/fixtures/GroupDerivative.schema.json
+++ b/test/fixtures/GroupDerivative.schema.json
@@ -15,14 +15,15 @@
               "strength": "REQUIRED"
             }
           },
-          "EntryType": {
-            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
+          "entryType": {
+            "type": "string",
+            "format": "uri"
           }
         },
         "description": "It is a coded element",
         "required": [
           "Value",
-          "EntryType"
+          "entryType"
         ]
       },
       "ElementValue": {
@@ -31,14 +32,15 @@
           "Value": {
             "$ref": "#/definitions/Simple"
           },
-          "EntryType": {
-            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
+          "entryType": {
+            "type": "string",
+            "format": "uri"
           }
         },
         "description": "It is an element with an element value",
         "required": [
           "Value",
-          "EntryType"
+          "entryType"
         ]
       },
       "ForeignElementValue": {
@@ -47,14 +49,15 @@
           "Value": {
             "$ref": "https://standardhealthrecord.org/test/shr/other/test#/definitions/Simple"
           },
-          "EntryType": {
-            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
+          "entryType": {
+            "type": "string",
+            "format": "uri"
           }
         },
         "description": "It is an element with a foreign element value",
         "required": [
           "Value",
-          "EntryType"
+          "entryType"
         ]
       },
       "Group": {
@@ -73,8 +76,9 @@
               "$ref": "#/definitions/ElementValue"
             }
           },
-          "EntryType": {
-            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
+          "entryType": {
+            "type": "string",
+            "format": "uri"
           }
         },
         "concepts": [
@@ -100,7 +104,7 @@
         "description": "It is a group of elements",
         "required": [
           "Simple",
-          "EntryType"
+          "entryType"
         ]
       },
       "GroupDerivative": {
@@ -131,8 +135,9 @@
           "Value": {
             "type": "string"
           },
-          "EntryType": {
-            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
+          "entryType": {
+            "type": "string",
+            "format": "uri"
           }
         },
         "concepts": [
@@ -149,7 +154,7 @@
         "description": "It is a simple element",
         "required": [
           "Value",
-          "EntryType"
+          "entryType"
         ]
       }
     },
@@ -171,8 +176,9 @@
           "Value": {
             "type": "string"
           },
-          "EntryType": {
-            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
+          "entryType": {
+            "type": "string",
+            "format": "uri"
           }
         },
         "concepts": [
@@ -189,7 +195,7 @@
         "description": "It is a simple element",
         "required": [
           "Value",
-          "EntryType"
+          "entryType"
         ]
       }
     }

--- a/test/fixtures/GroupDerivative.schema.json
+++ b/test/fixtures/GroupDerivative.schema.json
@@ -1,41 +1,5 @@
 {
-  "https://standardhealthrecord.org/schema/cimpl/builtin": {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "https://standardhealthrecord.org/schema/cimpl/builtin",
-    "title": "CIMPL Builtin Schema",
-    "definitions": {
-      "Concept": {
-        "type": "object",
-        "properties": {
-          "coding": {
-            "type": "array",
-            "minItems": 0,
-            "items": {
-              "$ref": "#/definitions/Coding"
-            }
-          }
-        },
-        "required": [
-          "coding"
-        ]
-      },
-      "Coding": {
-        "type": "object",
-        "properties": {
-          "code": {
-            "type": "string"
-          },
-          "system": {
-            "type": "string",
-            "format": "uri"
-          },
-          "display": {
-            "type": "string"
-          }
-        }
-      }
-    }
-  },
+  "https://standardhealthrecord.org/schema/cimpl/builtin": "inserted in test setup",
   "https://standardhealthrecord.org/test/shr/test": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
@@ -52,7 +16,7 @@
             }
           },
           "EntryType": {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
           }
         },
         "description": "It is a coded element",
@@ -68,7 +32,7 @@
             "$ref": "#/definitions/Simple"
           },
           "EntryType": {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
           }
         },
         "description": "It is an element with an element value",
@@ -84,7 +48,7 @@
             "$ref": "https://standardhealthrecord.org/test/shr/other/test#/definitions/Simple"
           },
           "EntryType": {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
           }
         },
         "description": "It is an element with a foreign element value",
@@ -110,7 +74,7 @@
             }
           },
           "EntryType": {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
           }
         },
         "concepts": [
@@ -142,7 +106,7 @@
       "GroupDerivative": {
         "allOf": [
           {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/Entry"
           },
           {
             "$ref": "#/definitions/Group"
@@ -168,7 +132,7 @@
             "type": "string"
           },
           "EntryType": {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
           }
         },
         "concepts": [
@@ -208,7 +172,7 @@
             "type": "string"
           },
           "EntryType": {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
           }
         },
         "concepts": [

--- a/test/fixtures/GroupPathClash.schema.json
+++ b/test/fixtures/GroupPathClash.schema.json
@@ -23,8 +23,9 @@
           "Value": {
             "type": "string"
           },
-          "EntryType": {
-            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
+          "entryType": {
+            "type": "string",
+            "format": "uri"
           }
         },
         "concepts": [
@@ -41,7 +42,7 @@
         "description": "It is a simple element",
         "required": [
           "Value",
-          "EntryType"
+          "entryType"
         ]
       }
     },
@@ -63,8 +64,9 @@
           "Value": {
             "type": "string"
           },
-          "EntryType": {
-            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
+          "entryType": {
+            "type": "string",
+            "format": "uri"
           }
         },
         "concepts": [
@@ -81,7 +83,7 @@
         "description": "It is a simple element",
         "required": [
           "Value",
-          "EntryType"
+          "entryType"
         ]
       }
     }

--- a/test/fixtures/GroupPathClash.schema.json
+++ b/test/fixtures/GroupPathClash.schema.json
@@ -1,41 +1,5 @@
 {
-  "https://standardhealthrecord.org/schema/cimpl/builtin": {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "https://standardhealthrecord.org/schema/cimpl/builtin",
-    "title": "CIMPL Builtin Schema",
-    "definitions": {
-      "Concept": {
-        "type": "object",
-        "properties": {
-          "coding": {
-            "type": "array",
-            "minItems": 0,
-            "items": {
-              "$ref": "#/definitions/Coding"
-            }
-          }
-        },
-        "required": [
-          "coding"
-        ]
-      },
-      "Coding": {
-        "type": "object",
-        "properties": {
-          "code": {
-            "type": "string"
-          },
-          "system": {
-            "type": "string",
-            "format": "uri"
-          },
-          "display": {
-            "type": "string"
-          }
-        }
-      }
-    }
-  },
+  "https://standardhealthrecord.org/schema/cimpl/builtin": "inserted in test setup",
   "https://standardhealthrecord.org/test/shr/test": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
@@ -44,7 +8,7 @@
       "GroupPathClash": {
         "allOf": [
           {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/Entry"
           },
           {
             "type": "object",
@@ -60,7 +24,7 @@
             "type": "string"
           },
           "EntryType": {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
           }
         },
         "concepts": [
@@ -100,7 +64,7 @@
             "type": "string"
           },
           "EntryType": {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
           }
         },
         "concepts": [

--- a/test/fixtures/GroupWithChoiceOfChoice.schema.json
+++ b/test/fixtures/GroupWithChoiceOfChoice.schema.json
@@ -15,14 +15,15 @@
               "strength": "REQUIRED"
             }
           },
-          "EntryType": {
-            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
+          "entryType": {
+            "type": "string",
+            "format": "uri"
           }
         },
         "description": "It is a coded element",
         "required": [
           "Value",
-          "EntryType"
+          "entryType"
         ]
       },
       "ElementValue": {
@@ -31,14 +32,15 @@
           "Value": {
             "$ref": "#/definitions/Simple"
           },
-          "EntryType": {
-            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
+          "entryType": {
+            "type": "string",
+            "format": "uri"
           }
         },
         "description": "It is an element with an element value",
         "required": [
           "Value",
-          "EntryType"
+          "entryType"
         ]
       },
       "ForeignElementValue": {
@@ -47,14 +49,15 @@
           "Value": {
             "$ref": "https://standardhealthrecord.org/test/shr/other/test#/definitions/Simple"
           },
-          "EntryType": {
-            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
+          "entryType": {
+            "type": "string",
+            "format": "uri"
           }
         },
         "description": "It is an element with a foreign element value",
         "required": [
           "Value",
-          "EntryType"
+          "entryType"
         ]
       },
       "GroupWithChoiceOfChoice": {
@@ -107,8 +110,9 @@
           "Value": {
             "type": "string"
           },
-          "EntryType": {
-            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
+          "entryType": {
+            "type": "string",
+            "format": "uri"
           }
         },
         "concepts": [
@@ -125,7 +129,7 @@
         "description": "It is a simple element",
         "required": [
           "Value",
-          "EntryType"
+          "entryType"
         ]
       }
     },
@@ -147,8 +151,9 @@
           "Value": {
             "type": "string"
           },
-          "EntryType": {
-            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
+          "entryType": {
+            "type": "string",
+            "format": "uri"
           }
         },
         "concepts": [
@@ -165,7 +170,7 @@
         "description": "It is a simple element",
         "required": [
           "Value",
-          "EntryType"
+          "entryType"
         ]
       }
     }

--- a/test/fixtures/GroupWithChoiceOfChoice.schema.json
+++ b/test/fixtures/GroupWithChoiceOfChoice.schema.json
@@ -1,41 +1,5 @@
 {
-  "https://standardhealthrecord.org/schema/cimpl/builtin": {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "https://standardhealthrecord.org/schema/cimpl/builtin",
-    "title": "CIMPL Builtin Schema",
-    "definitions": {
-      "Concept": {
-        "type": "object",
-        "properties": {
-          "coding": {
-            "type": "array",
-            "minItems": 0,
-            "items": {
-              "$ref": "#/definitions/Coding"
-            }
-          }
-        },
-        "required": [
-          "coding"
-        ]
-      },
-      "Coding": {
-        "type": "object",
-        "properties": {
-          "code": {
-            "type": "string"
-          },
-          "system": {
-            "type": "string",
-            "format": "uri"
-          },
-          "display": {
-            "type": "string"
-          }
-        }
-      }
-    }
-  },
+  "https://standardhealthrecord.org/schema/cimpl/builtin": "inserted in test setup",
   "https://standardhealthrecord.org/test/shr/test": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
@@ -52,7 +16,7 @@
             }
           },
           "EntryType": {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
           }
         },
         "description": "It is a coded element",
@@ -68,7 +32,7 @@
             "$ref": "#/definitions/Simple"
           },
           "EntryType": {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
           }
         },
         "description": "It is an element with an element value",
@@ -84,7 +48,7 @@
             "$ref": "https://standardhealthrecord.org/test/shr/other/test#/definitions/Simple"
           },
           "EntryType": {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
           }
         },
         "description": "It is an element with a foreign element value",
@@ -96,7 +60,7 @@
       "GroupWithChoiceOfChoice": {
         "allOf": [
           {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/Entry"
           },
           {
             "type": "object",
@@ -144,7 +108,7 @@
             "type": "string"
           },
           "EntryType": {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
           }
         },
         "concepts": [
@@ -184,7 +148,7 @@
             "type": "string"
           },
           "EntryType": {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
           }
         },
         "concepts": [

--- a/test/fixtures/IncludesCodeConstraints.schema.json
+++ b/test/fixtures/IncludesCodeConstraints.schema.json
@@ -1,41 +1,5 @@
 {
-  "https://standardhealthrecord.org/schema/cimpl/builtin": {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "https://standardhealthrecord.org/schema/cimpl/builtin",
-    "title": "CIMPL Builtin Schema",
-    "definitions": {
-      "Concept": {
-        "type": "object",
-        "properties": {
-          "coding": {
-            "type": "array",
-            "minItems": 0,
-            "items": {
-              "$ref": "#/definitions/Coding"
-            }
-          }
-        },
-        "required": [
-          "coding"
-        ]
-      },
-      "Coding": {
-        "type": "object",
-        "properties": {
-          "code": {
-            "type": "string"
-          },
-          "system": {
-            "type": "string",
-            "format": "uri"
-          },
-          "display": {
-            "type": "string"
-          }
-        }
-      }
-    }
-  },
+  "https://standardhealthrecord.org/schema/cimpl/builtin": "inserted in test setup",
   "https://standardhealthrecord.org/test/shr/test": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
@@ -44,7 +8,7 @@
       "IncludesCodesList": {
         "allOf": [
           {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/Entry"
           },
           {
             "type": "object",

--- a/test/fixtures/IncludesTypeConstraints.schema.json
+++ b/test/fixtures/IncludesTypeConstraints.schema.json
@@ -1,41 +1,5 @@
 {
-  "https://standardhealthrecord.org/schema/cimpl/builtin": {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "https://standardhealthrecord.org/schema/cimpl/builtin",
-    "title": "CIMPL Builtin Schema",
-    "definitions": {
-      "Concept": {
-        "type": "object",
-        "properties": {
-          "coding": {
-            "type": "array",
-            "minItems": 0,
-            "items": {
-              "$ref": "#/definitions/Coding"
-            }
-          }
-        },
-        "required": [
-          "coding"
-        ]
-      },
-      "Coding": {
-        "type": "object",
-        "properties": {
-          "code": {
-            "type": "string"
-          },
-          "system": {
-            "type": "string",
-            "format": "uri"
-          },
-          "display": {
-            "type": "string"
-          }
-        }
-      }
-    }
-  },
+  "https://standardhealthrecord.org/schema/cimpl/builtin": "inserted in test setup",
   "https://standardhealthrecord.org/test/shr/test": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
@@ -44,7 +8,7 @@
       "IncludesTypesList": {
         "allOf": [
           {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/Entry"
           },
           {
             "type": "object",
@@ -95,7 +59,7 @@
             "type": "string"
           },
           "EntryType": {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
           }
         },
         "concepts": [

--- a/test/fixtures/IncludesTypeConstraints.schema.json
+++ b/test/fixtures/IncludesTypeConstraints.schema.json
@@ -58,8 +58,9 @@
           "Value": {
             "type": "string"
           },
-          "EntryType": {
-            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
+          "entryType": {
+            "type": "string",
+            "format": "uri"
           }
         },
         "concepts": [
@@ -76,7 +77,7 @@
         "description": "It is a simple element",
         "required": [
           "Value",
-          "EntryType"
+          "entryType"
         ]
       },
       "SimpleChild": {

--- a/test/fixtures/NestedCardConstraint.schema.json
+++ b/test/fixtures/NestedCardConstraint.schema.json
@@ -39,13 +39,14 @@
           "OptionalValue": {
             "$ref": "#/definitions/OptionalValue"
           },
-          "EntryType": {
-            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
+          "entryType": {
+            "type": "string",
+            "format": "uri"
           }
         },
         "description": "An element with an optional field.",
         "required": [
-          "EntryType"
+          "entryType"
         ]
       },
       "OptionalValue": {
@@ -54,13 +55,14 @@
           "Value": {
             "type": "string"
           },
-          "EntryType": {
-            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
+          "entryType": {
+            "type": "string",
+            "format": "uri"
           }
         },
         "description": "An element with an optional value.",
         "required": [
-          "EntryType"
+          "entryType"
         ]
       }
     },

--- a/test/fixtures/NestedCardConstraint.schema.json
+++ b/test/fixtures/NestedCardConstraint.schema.json
@@ -1,41 +1,5 @@
 {
-  "https://standardhealthrecord.org/schema/cimpl/builtin": {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "https://standardhealthrecord.org/schema/cimpl/builtin",
-    "title": "CIMPL Builtin Schema",
-    "definitions": {
-      "Concept": {
-        "type": "object",
-        "properties": {
-          "coding": {
-            "type": "array",
-            "minItems": 0,
-            "items": {
-              "$ref": "#/definitions/Coding"
-            }
-          }
-        },
-        "required": [
-          "coding"
-        ]
-      },
-      "Coding": {
-        "type": "object",
-        "properties": {
-          "code": {
-            "type": "string"
-          },
-          "system": {
-            "type": "string",
-            "format": "uri"
-          },
-          "display": {
-            "type": "string"
-          }
-        }
-      }
-    }
-  },
+  "https://standardhealthrecord.org/schema/cimpl/builtin": "inserted in test setup",
   "https://standardhealthrecord.org/test/shr/test": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
@@ -44,7 +8,7 @@
       "NestedCardConstraint": {
         "allOf": [
           {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/Entry"
           },
           {
             "type": "object",
@@ -76,7 +40,7 @@
             "$ref": "#/definitions/OptionalValue"
           },
           "EntryType": {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
           }
         },
         "description": "An element with an optional field.",
@@ -91,7 +55,7 @@
             "type": "string"
           },
           "EntryType": {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
           }
         },
         "description": "An element with an optional value.",

--- a/test/fixtures/NestedListCardConstraints.schema.json
+++ b/test/fixtures/NestedListCardConstraints.schema.json
@@ -11,14 +11,15 @@
           "OptionalList": {
             "$ref": "#/definitions/OptionalList"
           },
-          "EntryType": {
-            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
+          "entryType": {
+            "type": "string",
+            "format": "uri"
           }
         },
         "description": "An element with a list field.",
         "required": [
           "OptionalList",
-          "EntryType"
+          "entryType"
         ]
       },
       "NestedListCardConstraints": {
@@ -76,13 +77,14 @@
               "type": "string"
             }
           },
-          "EntryType": {
-            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
+          "entryType": {
+            "type": "string",
+            "format": "uri"
           }
         },
         "description": "An element with an optional list.",
         "required": [
-          "EntryType"
+          "entryType"
         ]
       }
     },

--- a/test/fixtures/NestedListCardConstraints.schema.json
+++ b/test/fixtures/NestedListCardConstraints.schema.json
@@ -1,41 +1,5 @@
 {
-  "https://standardhealthrecord.org/schema/cimpl/builtin": {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "https://standardhealthrecord.org/schema/cimpl/builtin",
-    "title": "CIMPL Builtin Schema",
-    "definitions": {
-      "Concept": {
-        "type": "object",
-        "properties": {
-          "coding": {
-            "type": "array",
-            "minItems": 0,
-            "items": {
-              "$ref": "#/definitions/Coding"
-            }
-          }
-        },
-        "required": [
-          "coding"
-        ]
-      },
-      "Coding": {
-        "type": "object",
-        "properties": {
-          "code": {
-            "type": "string"
-          },
-          "system": {
-            "type": "string",
-            "format": "uri"
-          },
-          "display": {
-            "type": "string"
-          }
-        }
-      }
-    }
-  },
+  "https://standardhealthrecord.org/schema/cimpl/builtin": "inserted in test setup",
   "https://standardhealthrecord.org/test/shr/test": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
@@ -48,7 +12,7 @@
             "$ref": "#/definitions/OptionalList"
           },
           "EntryType": {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
           }
         },
         "description": "An element with a list field.",
@@ -60,7 +24,7 @@
       "NestedListCardConstraints": {
         "allOf": [
           {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/Entry"
           },
           {
             "type": "object",
@@ -113,7 +77,7 @@
             }
           },
           "EntryType": {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
           }
         },
         "description": "An element with an optional list.",

--- a/test/fixtures/NestedValueSetConstraints.schema.json
+++ b/test/fixtures/NestedValueSetConstraints.schema.json
@@ -15,14 +15,15 @@
               "strength": "REQUIRED"
             }
           },
-          "EntryType": {
-            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
+          "entryType": {
+            "type": "string",
+            "format": "uri"
           }
         },
         "description": "It is a coded element",
         "required": [
           "Value",
-          "EntryType"
+          "entryType"
         ]
       },
       "ElementValue": {
@@ -31,14 +32,15 @@
           "Value": {
             "$ref": "#/definitions/Simple"
           },
-          "EntryType": {
-            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
+          "entryType": {
+            "type": "string",
+            "format": "uri"
           }
         },
         "description": "It is an element with an element value",
         "required": [
           "Value",
-          "EntryType"
+          "entryType"
         ]
       },
       "ForeignElementValue": {
@@ -47,14 +49,15 @@
           "Value": {
             "$ref": "https://standardhealthrecord.org/test/shr/other/test#/definitions/Simple"
           },
-          "EntryType": {
-            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
+          "entryType": {
+            "type": "string",
+            "format": "uri"
           }
         },
         "description": "It is an element with a foreign element value",
         "required": [
           "Value",
-          "EntryType"
+          "entryType"
         ]
       },
       "Group": {
@@ -73,8 +76,9 @@
               "$ref": "#/definitions/ElementValue"
             }
           },
-          "EntryType": {
-            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
+          "entryType": {
+            "type": "string",
+            "format": "uri"
           }
         },
         "concepts": [
@@ -100,7 +104,7 @@
         "description": "It is a group of elements",
         "required": [
           "Simple",
-          "EntryType"
+          "entryType"
         ]
       },
       "NestedValueSetConstraints": {
@@ -135,8 +139,9 @@
           "Value": {
             "type": "string"
           },
-          "EntryType": {
-            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
+          "entryType": {
+            "type": "string",
+            "format": "uri"
           }
         },
         "concepts": [
@@ -153,7 +158,7 @@
         "description": "It is a simple element",
         "required": [
           "Value",
-          "EntryType"
+          "entryType"
         ]
       }
     },
@@ -175,8 +180,9 @@
           "Value": {
             "type": "string"
           },
-          "EntryType": {
-            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
+          "entryType": {
+            "type": "string",
+            "format": "uri"
           }
         },
         "concepts": [
@@ -193,7 +199,7 @@
         "description": "It is a simple element",
         "required": [
           "Value",
-          "EntryType"
+          "entryType"
         ]
       }
     }

--- a/test/fixtures/NestedValueSetConstraints.schema.json
+++ b/test/fixtures/NestedValueSetConstraints.schema.json
@@ -1,41 +1,5 @@
 {
-  "https://standardhealthrecord.org/schema/cimpl/builtin": {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "https://standardhealthrecord.org/schema/cimpl/builtin",
-    "title": "CIMPL Builtin Schema",
-    "definitions": {
-      "Concept": {
-        "type": "object",
-        "properties": {
-          "coding": {
-            "type": "array",
-            "minItems": 0,
-            "items": {
-              "$ref": "#/definitions/Coding"
-            }
-          }
-        },
-        "required": [
-          "coding"
-        ]
-      },
-      "Coding": {
-        "type": "object",
-        "properties": {
-          "code": {
-            "type": "string"
-          },
-          "system": {
-            "type": "string",
-            "format": "uri"
-          },
-          "display": {
-            "type": "string"
-          }
-        }
-      }
-    }
-  },
+  "https://standardhealthrecord.org/schema/cimpl/builtin": "inserted in test setup",
   "https://standardhealthrecord.org/test/shr/test": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
@@ -52,7 +16,7 @@
             }
           },
           "EntryType": {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
           }
         },
         "description": "It is a coded element",
@@ -68,7 +32,7 @@
             "$ref": "#/definitions/Simple"
           },
           "EntryType": {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
           }
         },
         "description": "It is an element with an element value",
@@ -84,7 +48,7 @@
             "$ref": "https://standardhealthrecord.org/test/shr/other/test#/definitions/Simple"
           },
           "EntryType": {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
           }
         },
         "description": "It is an element with a foreign element value",
@@ -110,7 +74,7 @@
             }
           },
           "EntryType": {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
           }
         },
         "concepts": [
@@ -142,7 +106,7 @@
       "NestedValueSetConstraints": {
         "allOf": [
           {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/Entry"
           },
           {
             "$ref": "#/definitions/Group"
@@ -172,7 +136,7 @@
             "type": "string"
           },
           "EntryType": {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
           }
         },
         "concepts": [
@@ -212,7 +176,7 @@
             "type": "string"
           },
           "EntryType": {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
           }
         },
         "concepts": [

--- a/test/fixtures/NotDone.schema.json
+++ b/test/fixtures/NotDone.schema.json
@@ -1,41 +1,5 @@
 {
-  "https://standardhealthrecord.org/schema/cimpl/builtin": {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "https://standardhealthrecord.org/schema/cimpl/builtin",
-    "title": "CIMPL Builtin Schema",
-    "definitions": {
-      "Concept": {
-        "type": "object",
-        "properties": {
-          "coding": {
-            "type": "array",
-            "minItems": 0,
-            "items": {
-              "$ref": "#/definitions/Coding"
-            }
-          }
-        },
-        "required": [
-          "coding"
-        ]
-      },
-      "Coding": {
-        "type": "object",
-        "properties": {
-          "code": {
-            "type": "string"
-          },
-          "system": {
-            "type": "string",
-            "format": "uri"
-          },
-          "display": {
-            "type": "string"
-          }
-        }
-      }
-    }
-  },
+  "https://standardhealthrecord.org/schema/cimpl/builtin": "inserted in test setup",
   "https://standardhealthrecord.org/test/shr/test": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
@@ -44,7 +8,7 @@
       "NotDone": {
         "allOf": [
           {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/Entry"
           },
           {
             "type": "object",

--- a/test/fixtures/NotDoneDerivative.schema.json
+++ b/test/fixtures/NotDoneDerivative.schema.json
@@ -1,41 +1,5 @@
 {
-  "https://standardhealthrecord.org/schema/cimpl/builtin": {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "https://standardhealthrecord.org/schema/cimpl/builtin",
-    "title": "CIMPL Builtin Schema",
-    "definitions": {
-      "Concept": {
-        "type": "object",
-        "properties": {
-          "coding": {
-            "type": "array",
-            "minItems": 0,
-            "items": {
-              "$ref": "#/definitions/Coding"
-            }
-          }
-        },
-        "required": [
-          "coding"
-        ]
-      },
-      "Coding": {
-        "type": "object",
-        "properties": {
-          "code": {
-            "type": "string"
-          },
-          "system": {
-            "type": "string",
-            "format": "uri"
-          },
-          "display": {
-            "type": "string"
-          }
-        }
-      }
-    }
-  },
+  "https://standardhealthrecord.org/schema/cimpl/builtin": "inserted in test setup",
   "https://standardhealthrecord.org/test/shr/test": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
@@ -44,7 +8,7 @@
       "NotDoneDerivative": {
         "allOf": [
           {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/Entry"
           },
           {
             "$ref": "#/definitions/ValuelessElement"
@@ -80,7 +44,7 @@
             "type": "string"
           },
           "EntryType": {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
           }
         },
         "concepts": [
@@ -107,7 +71,7 @@
             "$ref": "#/definitions/Simple"
           },
           "EntryType": {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
           }
         },
         "description": "An element with no value.",

--- a/test/fixtures/NotDoneDerivative.schema.json
+++ b/test/fixtures/NotDoneDerivative.schema.json
@@ -43,8 +43,9 @@
           "Value": {
             "type": "string"
           },
-          "EntryType": {
-            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
+          "entryType": {
+            "type": "string",
+            "format": "uri"
           }
         },
         "concepts": [
@@ -61,7 +62,7 @@
         "description": "It is a simple element",
         "required": [
           "Value",
-          "EntryType"
+          "entryType"
         ]
       },
       "ValuelessElement": {
@@ -70,14 +71,15 @@
           "Simple": {
             "$ref": "#/definitions/Simple"
           },
-          "EntryType": {
-            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
+          "entryType": {
+            "type": "string",
+            "format": "uri"
           }
         },
         "description": "An element with no value.",
         "required": [
           "Simple",
-          "EntryType"
+          "entryType"
         ]
       }
     },

--- a/test/fixtures/ReferenceChoice.schema.json
+++ b/test/fixtures/ReferenceChoice.schema.json
@@ -1,41 +1,5 @@
 {
-  "https://standardhealthrecord.org/schema/cimpl/builtin": {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "https://standardhealthrecord.org/schema/cimpl/builtin",
-    "title": "CIMPL Builtin Schema",
-    "definitions": {
-      "Concept": {
-        "type": "object",
-        "properties": {
-          "coding": {
-            "type": "array",
-            "minItems": 0,
-            "items": {
-              "$ref": "#/definitions/Coding"
-            }
-          }
-        },
-        "required": [
-          "coding"
-        ]
-      },
-      "Coding": {
-        "type": "object",
-        "properties": {
-          "code": {
-            "type": "string"
-          },
-          "system": {
-            "type": "string",
-            "format": "uri"
-          },
-          "display": {
-            "type": "string"
-          }
-        }
-      }
-    }
-  },
+  "https://standardhealthrecord.org/schema/cimpl/builtin": "inserted in test setup",
   "https://standardhealthrecord.org/test/shr/test": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
@@ -44,7 +8,7 @@
       "Coded": {
         "allOf": [
           {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/Entry"
           },
           {
             "type": "object",
@@ -67,7 +31,7 @@
       "ReferenceChoice": {
         "allOf": [
           {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/Entry"
           },
           {
             "type": "object",
@@ -122,7 +86,7 @@
       "Simple": {
         "allOf": [
           {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/Entry"
           },
           {
             "type": "object",

--- a/test/fixtures/Simple.schema.json
+++ b/test/fixtures/Simple.schema.json
@@ -1,41 +1,5 @@
 {
-  "https://standardhealthrecord.org/schema/cimpl/builtin": {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "https://standardhealthrecord.org/schema/cimpl/builtin",
-    "title": "CIMPL Builtin Schema",
-    "definitions": {
-      "Concept": {
-        "type": "object",
-        "properties": {
-          "coding": {
-            "type": "array",
-            "minItems": 0,
-            "items": {
-              "$ref": "#/definitions/Coding"
-            }
-          }
-        },
-        "required": [
-          "coding"
-        ]
-      },
-      "Coding": {
-        "type": "object",
-        "properties": {
-          "code": {
-            "type": "string"
-          },
-          "system": {
-            "type": "string",
-            "format": "uri"
-          },
-          "display": {
-            "type": "string"
-          }
-        }
-      }
-    }
-  },
+  "https://standardhealthrecord.org/schema/cimpl/builtin": "inserted in test setup",
   "https://standardhealthrecord.org/test/shr/test": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
@@ -44,7 +8,7 @@
       "Simple": {
         "allOf": [
           {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/Entry"
           },
           {
             "type": "object",

--- a/test/fixtures/SimpleReference.schema.json
+++ b/test/fixtures/SimpleReference.schema.json
@@ -1,41 +1,5 @@
 {
-  "https://standardhealthrecord.org/schema/cimpl/builtin": {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "https://standardhealthrecord.org/schema/cimpl/builtin",
-    "title": "CIMPL Builtin Schema",
-    "definitions": {
-      "Concept": {
-        "type": "object",
-        "properties": {
-          "coding": {
-            "type": "array",
-            "minItems": 0,
-            "items": {
-              "$ref": "#/definitions/Coding"
-            }
-          }
-        },
-        "required": [
-          "coding"
-        ]
-      },
-      "Coding": {
-        "type": "object",
-        "properties": {
-          "code": {
-            "type": "string"
-          },
-          "system": {
-            "type": "string",
-            "format": "uri"
-          },
-          "display": {
-            "type": "string"
-          }
-        }
-      }
-    }
-  },
+  "https://standardhealthrecord.org/schema/cimpl/builtin": "inserted in test setup",
   "https://standardhealthrecord.org/test/shr/test": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
@@ -44,7 +8,7 @@
       "Simple": {
         "allOf": [
           {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/Entry"
           },
           {
             "type": "object",
@@ -74,7 +38,7 @@
       "SimpleReference": {
         "allOf": [
           {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/Entry"
           },
           {
             "type": "object",

--- a/test/fixtures/TwoDeepElementValue.schema.json
+++ b/test/fixtures/TwoDeepElementValue.schema.json
@@ -1,41 +1,5 @@
 {
-  "https://standardhealthrecord.org/schema/cimpl/builtin": {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "https://standardhealthrecord.org/schema/cimpl/builtin",
-    "title": "CIMPL Builtin Schema",
-    "definitions": {
-      "Concept": {
-        "type": "object",
-        "properties": {
-          "coding": {
-            "type": "array",
-            "minItems": 0,
-            "items": {
-              "$ref": "#/definitions/Coding"
-            }
-          }
-        },
-        "required": [
-          "coding"
-        ]
-      },
-      "Coding": {
-        "type": "object",
-        "properties": {
-          "code": {
-            "type": "string"
-          },
-          "system": {
-            "type": "string",
-            "format": "uri"
-          },
-          "display": {
-            "type": "string"
-          }
-        }
-      }
-    }
-  },
+  "https://standardhealthrecord.org/schema/cimpl/builtin": "inserted in test setup",
   "https://standardhealthrecord.org/test/shr/test": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
@@ -48,7 +12,7 @@
             "$ref": "#/definitions/Simple"
           },
           "EntryType": {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
           }
         },
         "description": "It is an element with an element value",
@@ -64,7 +28,7 @@
             "type": "string"
           },
           "EntryType": {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
           }
         },
         "concepts": [
@@ -87,7 +51,7 @@
       "TwoDeepElementValue": {
         "allOf": [
           {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/Entry"
           },
           {
             "type": "object",

--- a/test/fixtures/TwoDeepElementValue.schema.json
+++ b/test/fixtures/TwoDeepElementValue.schema.json
@@ -11,14 +11,15 @@
           "Value": {
             "$ref": "#/definitions/Simple"
           },
-          "EntryType": {
-            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
+          "entryType": {
+            "type": "string",
+            "format": "uri"
           }
         },
         "description": "It is an element with an element value",
         "required": [
           "Value",
-          "EntryType"
+          "entryType"
         ]
       },
       "Simple": {
@@ -27,8 +28,9 @@
           "Value": {
             "type": "string"
           },
-          "EntryType": {
-            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
+          "entryType": {
+            "type": "string",
+            "format": "uri"
           }
         },
         "concepts": [
@@ -45,7 +47,7 @@
         "description": "It is a simple element",
         "required": [
           "Value",
-          "EntryType"
+          "entryType"
         ]
       },
       "TwoDeepElementValue": {

--- a/test/fixtures/TypeConstrainedChoices.schema.json
+++ b/test/fixtures/TypeConstrainedChoices.schema.json
@@ -1,41 +1,5 @@
 {
-  "https://standardhealthrecord.org/schema/cimpl/builtin": {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "https://standardhealthrecord.org/schema/cimpl/builtin",
-    "title": "CIMPL Builtin Schema",
-    "definitions": {
-      "Concept": {
-        "type": "object",
-        "properties": {
-          "coding": {
-            "type": "array",
-            "minItems": 0,
-            "items": {
-              "$ref": "#/definitions/Coding"
-            }
-          }
-        },
-        "required": [
-          "coding"
-        ]
-      },
-      "Coding": {
-        "type": "object",
-        "properties": {
-          "code": {
-            "type": "string"
-          },
-          "system": {
-            "type": "string",
-            "format": "uri"
-          },
-          "display": {
-            "type": "string"
-          }
-        }
-      }
-    }
-  },
+  "https://standardhealthrecord.org/schema/cimpl/builtin": "inserted in test setup",
   "https://standardhealthrecord.org/test/shr/test": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
@@ -62,7 +26,7 @@
             ]
           },
           "EntryType": {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
           }
         },
         "description": "It is an element with a choice",
@@ -78,7 +42,7 @@
             "$ref": "#/definitions/Choice"
           },
           "EntryType": {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
           }
         },
         "description": "It is an element with a choice value.",
@@ -98,7 +62,7 @@
             }
           },
           "EntryType": {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
           }
         },
         "description": "It is a coded element",
@@ -114,7 +78,7 @@
             "$ref": "#/definitions/ChoiceValue"
           },
           "EntryType": {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
           }
         },
         "description": "It is an element with a a field with a choice.",
@@ -140,7 +104,7 @@
             ]
           },
           "EntryType": {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
           }
         },
         "description": "It is an element with a choice with a constraint.",
@@ -152,7 +116,7 @@
       "TypeConstrainedChoiceWithPath": {
         "allOf": [
           {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/Entry"
           },
           {
             "type": "object",

--- a/test/fixtures/TypeConstrainedChoices.schema.json
+++ b/test/fixtures/TypeConstrainedChoices.schema.json
@@ -25,14 +25,15 @@
               }
             ]
           },
-          "EntryType": {
-            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
+          "entryType": {
+            "type": "string",
+            "format": "uri"
           }
         },
         "description": "It is an element with a choice",
         "required": [
           "Value",
-          "EntryType"
+          "entryType"
         ]
       },
       "ChoiceValue": {
@@ -41,14 +42,15 @@
           "Value": {
             "$ref": "#/definitions/Choice"
           },
-          "EntryType": {
-            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
+          "entryType": {
+            "type": "string",
+            "format": "uri"
           }
         },
         "description": "It is an element with a choice value.",
         "required": [
           "Value",
-          "EntryType"
+          "entryType"
         ]
       },
       "Coded": {
@@ -61,14 +63,15 @@
               "strength": "REQUIRED"
             }
           },
-          "EntryType": {
-            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
+          "entryType": {
+            "type": "string",
+            "format": "uri"
           }
         },
         "description": "It is a coded element",
         "required": [
           "Value",
-          "EntryType"
+          "entryType"
         ]
       },
       "TwoDeepChoiceField": {
@@ -77,13 +80,14 @@
           "ChoiceValue": {
             "$ref": "#/definitions/ChoiceValue"
           },
-          "EntryType": {
-            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
+          "entryType": {
+            "type": "string",
+            "format": "uri"
           }
         },
         "description": "It is an element with a a field with a choice.",
         "required": [
-          "EntryType"
+          "entryType"
         ]
       },
       "TypeConstrainedChoice": {
@@ -103,14 +107,15 @@
               }
             ]
           },
-          "EntryType": {
-            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
+          "entryType": {
+            "type": "string",
+            "format": "uri"
           }
         },
         "description": "It is an element with a choice with a constraint.",
         "required": [
           "Choice",
-          "EntryType"
+          "entryType"
         ]
       },
       "TypeConstrainedChoiceWithPath": {

--- a/test/fixtures/TypeConstrainedReference.schema.json
+++ b/test/fixtures/TypeConstrainedReference.schema.json
@@ -1,41 +1,5 @@
 {
-  "https://standardhealthrecord.org/schema/cimpl/builtin": {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "https://standardhealthrecord.org/schema/cimpl/builtin",
-    "title": "CIMPL Builtin Schema",
-    "definitions": {
-      "Concept": {
-        "type": "object",
-        "properties": {
-          "coding": {
-            "type": "array",
-            "minItems": 0,
-            "items": {
-              "$ref": "#/definitions/Coding"
-            }
-          }
-        },
-        "required": [
-          "coding"
-        ]
-      },
-      "Coding": {
-        "type": "object",
-        "properties": {
-          "code": {
-            "type": "string"
-          },
-          "system": {
-            "type": "string",
-            "format": "uri"
-          },
-          "display": {
-            "type": "string"
-          }
-        }
-      }
-    }
-  },
+  "https://standardhealthrecord.org/schema/cimpl/builtin": "inserted in test setup",
   "https://standardhealthrecord.org/test/shr/test": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
@@ -44,7 +8,7 @@
       "Simple": {
         "allOf": [
           {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/Entry"
           },
           {
             "type": "object",
@@ -109,7 +73,7 @@
             ]
           },
           "EntryType": {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
           }
         },
         "description": "It is a reference to a simple element",
@@ -121,7 +85,7 @@
       "TypeConstrainedReference": {
         "allOf": [
           {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/Entry"
           },
           {
             "$ref": "#/definitions/SimpleReference"

--- a/test/fixtures/TypeConstrainedReference.schema.json
+++ b/test/fixtures/TypeConstrainedReference.schema.json
@@ -72,14 +72,15 @@
               "http://standardhealthrecord.org/spec/shr/test/Simple"
             ]
           },
-          "EntryType": {
-            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
+          "entryType": {
+            "type": "string",
+            "format": "uri"
           }
         },
         "description": "It is a reference to a simple element",
         "required": [
           "Value",
-          "EntryType"
+          "entryType"
         ]
       },
       "TypeConstrainedReference": {

--- a/test/fixtures/TypeConstraints.schema.json
+++ b/test/fixtures/TypeConstraints.schema.json
@@ -15,14 +15,15 @@
               "strength": "REQUIRED"
             }
           },
-          "EntryType": {
-            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
+          "entryType": {
+            "type": "string",
+            "format": "uri"
           }
         },
         "description": "It is a coded element",
         "required": [
           "Value",
-          "EntryType"
+          "entryType"
         ]
       },
       "ElementValue": {
@@ -31,14 +32,15 @@
           "Value": {
             "$ref": "#/definitions/Simple"
           },
-          "EntryType": {
-            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
+          "entryType": {
+            "type": "string",
+            "format": "uri"
           }
         },
         "description": "It is an element with an element value",
         "required": [
           "Value",
-          "EntryType"
+          "entryType"
         ]
       },
       "ForeignElementValue": {
@@ -47,14 +49,15 @@
           "Value": {
             "$ref": "https://standardhealthrecord.org/test/shr/other/test#/definitions/Simple"
           },
-          "EntryType": {
-            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
+          "entryType": {
+            "type": "string",
+            "format": "uri"
           }
         },
         "description": "It is an element with a foreign element value",
         "required": [
           "Value",
-          "EntryType"
+          "entryType"
         ]
       },
       "Group": {
@@ -73,8 +76,9 @@
               "$ref": "#/definitions/ElementValue"
             }
           },
-          "EntryType": {
-            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
+          "entryType": {
+            "type": "string",
+            "format": "uri"
           }
         },
         "concepts": [
@@ -100,7 +104,7 @@
         "description": "It is a group of elements",
         "required": [
           "Simple",
-          "EntryType"
+          "entryType"
         ]
       },
       "GroupDerivative": {
@@ -142,8 +146,9 @@
           "Value": {
             "type": "string"
           },
-          "EntryType": {
-            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
+          "entryType": {
+            "type": "string",
+            "format": "uri"
           }
         },
         "concepts": [
@@ -160,7 +165,7 @@
         "description": "It is a simple element",
         "required": [
           "Value",
-          "EntryType"
+          "entryType"
         ]
       },
       "SimpleChild": {
@@ -194,8 +199,9 @@
           "Value": {
             "type": "string"
           },
-          "EntryType": {
-            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
+          "entryType": {
+            "type": "string",
+            "format": "uri"
           }
         },
         "concepts": [
@@ -212,7 +218,7 @@
         "description": "It is a simple element",
         "required": [
           "Value",
-          "EntryType"
+          "entryType"
         ]
       }
     }

--- a/test/fixtures/TypeConstraints.schema.json
+++ b/test/fixtures/TypeConstraints.schema.json
@@ -1,41 +1,5 @@
 {
-  "https://standardhealthrecord.org/schema/cimpl/builtin": {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "https://standardhealthrecord.org/schema/cimpl/builtin",
-    "title": "CIMPL Builtin Schema",
-    "definitions": {
-      "Concept": {
-        "type": "object",
-        "properties": {
-          "coding": {
-            "type": "array",
-            "minItems": 0,
-            "items": {
-              "$ref": "#/definitions/Coding"
-            }
-          }
-        },
-        "required": [
-          "coding"
-        ]
-      },
-      "Coding": {
-        "type": "object",
-        "properties": {
-          "code": {
-            "type": "string"
-          },
-          "system": {
-            "type": "string",
-            "format": "uri"
-          },
-          "display": {
-            "type": "string"
-          }
-        }
-      }
-    }
-  },
+  "https://standardhealthrecord.org/schema/cimpl/builtin": "inserted in test setup",
   "https://standardhealthrecord.org/test/shr/test": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
@@ -52,7 +16,7 @@
             }
           },
           "EntryType": {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
           }
         },
         "description": "It is a coded element",
@@ -68,7 +32,7 @@
             "$ref": "#/definitions/Simple"
           },
           "EntryType": {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
           }
         },
         "description": "It is an element with an element value",
@@ -84,7 +48,7 @@
             "$ref": "https://standardhealthrecord.org/test/shr/other/test#/definitions/Simple"
           },
           "EntryType": {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
           }
         },
         "description": "It is an element with a foreign element value",
@@ -110,7 +74,7 @@
             }
           },
           "EntryType": {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
           }
         },
         "concepts": [
@@ -142,7 +106,7 @@
       "GroupDerivative": {
         "allOf": [
           {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/Entry"
           },
           {
             "$ref": "#/definitions/Group"
@@ -179,7 +143,7 @@
             "type": "string"
           },
           "EntryType": {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
           }
         },
         "concepts": [
@@ -231,7 +195,7 @@
             "type": "string"
           },
           "EntryType": {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
           }
         },
         "concepts": [

--- a/test/fixtures/TypeConstraintsWithPath.schema.json
+++ b/test/fixtures/TypeConstraintsWithPath.schema.json
@@ -69,14 +69,15 @@
           "Simple": {
             "$ref": "#/definitions/Simple"
           },
-          "EntryType": {
-            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
+          "entryType": {
+            "type": "string",
+            "format": "uri"
           }
         },
         "description": "It is an element with a field.",
         "required": [
           "Simple",
-          "EntryType"
+          "entryType"
         ]
       },
       "NestedField": {
@@ -85,13 +86,14 @@
           "TwoDeepElementField": {
             "$ref": "#/definitions/TwoDeepElementField"
           },
-          "EntryType": {
-            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
+          "entryType": {
+            "type": "string",
+            "format": "uri"
           }
         },
         "description": "It is an element with a nested field.",
         "required": [
-          "EntryType"
+          "entryType"
         ]
       },
       "Simple": {
@@ -100,8 +102,9 @@
           "Value": {
             "type": "string"
           },
-          "EntryType": {
-            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
+          "entryType": {
+            "type": "string",
+            "format": "uri"
           }
         },
         "concepts": [
@@ -118,7 +121,7 @@
         "description": "It is a simple element",
         "required": [
           "Value",
-          "EntryType"
+          "entryType"
         ]
       },
       "SimpleChild": {
@@ -139,14 +142,15 @@
           "ElementField": {
             "$ref": "#/definitions/ElementField"
           },
-          "EntryType": {
-            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
+          "entryType": {
+            "type": "string",
+            "format": "uri"
           }
         },
         "description": "It is an element with a two-deep element field",
         "required": [
           "ElementField",
-          "EntryType"
+          "entryType"
         ]
       }
     },

--- a/test/fixtures/TypeConstraintsWithPath.schema.json
+++ b/test/fixtures/TypeConstraintsWithPath.schema.json
@@ -1,41 +1,5 @@
 {
-  "https://standardhealthrecord.org/schema/cimpl/builtin": {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "https://standardhealthrecord.org/schema/cimpl/builtin",
-    "title": "CIMPL Builtin Schema",
-    "definitions": {
-      "Concept": {
-        "type": "object",
-        "properties": {
-          "coding": {
-            "type": "array",
-            "minItems": 0,
-            "items": {
-              "$ref": "#/definitions/Coding"
-            }
-          }
-        },
-        "required": [
-          "coding"
-        ]
-      },
-      "Coding": {
-        "type": "object",
-        "properties": {
-          "code": {
-            "type": "string"
-          },
-          "system": {
-            "type": "string",
-            "format": "uri"
-          },
-          "display": {
-            "type": "string"
-          }
-        }
-      }
-    }
-  },
+  "https://standardhealthrecord.org/schema/cimpl/builtin": "inserted in test setup",
   "https://standardhealthrecord.org/test/shr/test": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://standardhealthrecord.org/test/shr/test",
@@ -44,7 +8,7 @@
       "ConstrainedPath": {
         "allOf": [
           {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/Entry"
           },
           {
             "$ref": "#/definitions/NestedField"
@@ -71,7 +35,7 @@
       "ConstrainedPathNoInheritance": {
         "allOf": [
           {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/Entry"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/Entry"
           },
           {
             "type": "object",
@@ -106,7 +70,7 @@
             "$ref": "#/definitions/Simple"
           },
           "EntryType": {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
           }
         },
         "description": "It is an element with a field.",
@@ -122,7 +86,7 @@
             "$ref": "#/definitions/TwoDeepElementField"
           },
           "EntryType": {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
           }
         },
         "description": "It is an element with a nested field.",
@@ -137,7 +101,7 @@
             "type": "string"
           },
           "EntryType": {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
           }
         },
         "concepts": [
@@ -176,7 +140,7 @@
             "$ref": "#/definitions/ElementField"
           },
           "EntryType": {
-            "$ref": "https://standardhealthrecord.org/test/shr/base#/definitions/EntryType"
+            "$ref": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryType"
           }
         },
         "description": "It is an element with a two-deep element field",

--- a/test/fixtures/instances/ChoiceOfChoice.json
+++ b/test/fixtures/instances/ChoiceOfChoice.json
@@ -1,8 +1,7 @@
 {
-  "ShrId": { "Value": "patient-id", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId"} },
-  "EntryId": { "Value": "my-id", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId"} },
+  "ShrId": { "Value": "patient-id", "EntryType": { "Value": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/ShrId"} },
+  "EntryId": { "Value": "my-id", "EntryType": { "Value": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryId"} },
   "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/test/ChoiceOfChoice"},
   "CreationTime": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"} },
-  "LastUpdated": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"} },
   "Value": 35
 }

--- a/test/fixtures/instances/ChoiceOfChoice.json
+++ b/test/fixtures/instances/ChoiceOfChoice.json
@@ -1,7 +1,7 @@
 {
-  "ShrId": { "Value": "patient-id", "EntryType": { "Value": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/ShrId"} },
-  "EntryId": { "Value": "my-id", "EntryType": { "Value": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryId"} },
-  "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/test/ChoiceOfChoice"},
-  "CreationTime": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"} },
+  "shrId": "patient-id",
+  "entryId": "my-id",
+  "entryType": "http://standardhealthrecord.org/spec/shr/test/ChoiceOfChoice",
+  "CreationTime": { "Value": "2017-11-30T12:34:56Z", "entryType": "http://standardhealthrecord.org/spec/shr/core/CreationTime" },
   "Value": 35
 }

--- a/test/fixtures/instances/Coded.json
+++ b/test/fixtures/instances/Coded.json
@@ -1,8 +1,7 @@
 {
-  "ShrId": { "Value": "patient-id", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId"} },
-  "EntryId": { "Value": "my-id", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId"} },
+  "ShrId": { "Value": "patient-id", "EntryType": { "Value": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/ShrId"} },
+  "EntryId": { "Value": "my-id", "EntryType": { "Value": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryId"} },
   "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/test/Coded"},
   "CreationTime": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"} },
-  "LastUpdated": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"} },
   "Value": { "coding": [{ "code": "bar", "system": "urn:some-namespace:foo" }] }
 }

--- a/test/fixtures/instances/Coded.json
+++ b/test/fixtures/instances/Coded.json
@@ -1,7 +1,7 @@
 {
-  "ShrId": { "Value": "patient-id", "EntryType": { "Value": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/ShrId"} },
-  "EntryId": { "Value": "my-id", "EntryType": { "Value": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryId"} },
-  "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/test/Coded"},
-  "CreationTime": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"} },
+  "shrId": "patient-id",
+  "entryId": "my-id",
+  "entryType": "http://standardhealthrecord.org/spec/shr/test/Coded",
+  "CreationTime": { "Value": "2017-11-30T12:34:56Z", "entryType": "http://standardhealthrecord.org/spec/shr/core/CreationTime" },
   "Value": { "coding": [{ "code": "bar", "system": "urn:some-namespace:foo" }] }
 }

--- a/test/fixtures/instances/NestedCardConstraint.json
+++ b/test/fixtures/instances/NestedCardConstraint.json
@@ -1,9 +1,8 @@
 {
-  "ShrId": { "Value": "patient-id", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId"} },
-  "EntryId": { "Value": "my-id-3", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId"} },
+  "ShrId": { "Value": "patient-id", "EntryType": { "Value": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/ShrId"} },
+  "EntryId": { "Value": "my-id-3", "EntryType": { "Value": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryId"} },
   "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/test/NestedCardConstraint"},
   "CreationTime": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"} },
-  "LastUpdated": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"} },
   "OptionalField": {
     "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/test/OptionalField"},
     "OptionalValue": {

--- a/test/fixtures/instances/NestedCardConstraint.json
+++ b/test/fixtures/instances/NestedCardConstraint.json
@@ -1,12 +1,12 @@
 {
-  "ShrId": { "Value": "patient-id", "EntryType": { "Value": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/ShrId"} },
-  "EntryId": { "Value": "my-id-3", "EntryType": { "Value": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryId"} },
-  "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/test/NestedCardConstraint"},
-  "CreationTime": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"} },
+  "shrId": "patient-id",
+  "entryId": "my-id-3",
+  "entryType": "http://standardhealthrecord.org/spec/shr/test/NestedCardConstraint",
+  "CreationTime": { "Value": "2017-11-30T12:34:56Z", "entryType": "http://standardhealthrecord.org/spec/shr/core/CreationTime" },
   "OptionalField": {
-    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/test/OptionalField"},
+    "entryType": "http://standardhealthrecord.org/spec/shr/test/OptionalField",
     "OptionalValue": {
-      "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/test/OptionalValue"},
+      "entryType": "http://standardhealthrecord.org/spec/shr/test/OptionalValue",
       "comment": "The value is optional."
     }
   }

--- a/test/fixtures/instances/Simple.json
+++ b/test/fixtures/instances/Simple.json
@@ -1,7 +1,7 @@
 {
-  "ShrId": { "Value": "patient-id", "EntryType": { "Value": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/ShrId"} },
-  "EntryId": { "Value": "my-id", "EntryType": { "Value": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryId"} },
-  "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/test/Simple"},
-  "CreationTime": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"} },
+  "shrId": "patient-id",
+  "entryId": "my-id",
+  "entryType": "http://standardhealthrecord.org/spec/shr/test/Simple",
+  "CreationTime": { "Value": "2017-11-30T12:34:56Z", "entryType": "http://standardhealthrecord.org/spec/shr/core/CreationTime" },
   "Value": "Hello World!"
 }

--- a/test/fixtures/instances/Simple.json
+++ b/test/fixtures/instances/Simple.json
@@ -1,8 +1,7 @@
 {
-  "ShrId": { "Value": "patient-id", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId"} },
-  "EntryId": { "Value": "my-id", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId"} },
+  "ShrId": { "Value": "patient-id", "EntryType": { "Value": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/ShrId"} },
+  "EntryId": { "Value": "my-id", "EntryType": { "Value": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryId"} },
   "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/test/Simple"},
   "CreationTime": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"} },
-  "LastUpdated": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"} },
   "Value": "Hello World!"
 }

--- a/test/fixtures/instances/SimpleReference.json
+++ b/test/fixtures/instances/SimpleReference.json
@@ -1,9 +1,8 @@
 {
-  "ShrId": { "Value": "patient-id", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId"} },
-  "EntryId": { "Value": "my-id", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId"} },
+  "ShrId": { "Value": "patient-id", "EntryType": { "Value": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/ShrId"} },
+  "EntryId": { "Value": "my-id", "EntryType": { "Value": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryId"} },
   "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/test/SimpleReference"},
   "CreationTime": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"} },
-  "LastUpdated": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"} },
   "Value": {
     "_ShrId": "patient-id",
     "_EntryId": "another-id",

--- a/test/fixtures/instances/SimpleReference.json
+++ b/test/fixtures/instances/SimpleReference.json
@@ -1,8 +1,8 @@
 {
-  "ShrId": { "Value": "patient-id", "EntryType": { "Value": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/ShrId"} },
-  "EntryId": { "Value": "my-id", "EntryType": { "Value": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryId"} },
-  "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/test/SimpleReference"},
-  "CreationTime": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"} },
+  "shrId": "patient-id",
+  "entryId": "my-id",
+  "entryType": "http://standardhealthrecord.org/spec/shr/test/SimpleReference",
+  "CreationTime": { "Value": "2017-11-30T12:34:56Z", "entryType": "http://standardhealthrecord.org/spec/shr/core/CreationTime" },
   "Value": {
     "_ShrId": "patient-id",
     "_EntryId": "another-id",

--- a/test/fixtures/instances/TwoDeepElementValue.json
+++ b/test/fixtures/instances/TwoDeepElementValue.json
@@ -1,18 +1,18 @@
 {
-  "ShrId": { "Value": "patient-id", "EntryType": { "Value": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/ShrId"} },
-  "EntryId": { "Value": "my-id-3", "EntryType": { "Value": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryId"} },
-  "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/test/TwoDeepElementValue"},
-  "CreationTime": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"} },
+  "shrId": "patient-id",
+  "entryId": "my-id-3",
+  "entryType": "http://standardhealthrecord.org/spec/shr/test/TwoDeepElementValue",
+  "CreationTime": { "Value": "2017-11-30T12:34:56Z", "entryType": "http://standardhealthrecord.org/spec/shr/core/CreationTime" },
   "Value": {
-    "ShrId": { "Value": "patient-id", "EntryType": { "Value": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/ShrId"} },
-    "EntryId": { "Value": "my-id-2", "EntryType": { "Value": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryId"}  },
-    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/test/ElementValue"},
-    "CreationTime": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"} },
+    "shrId": "patient-id",
+    "entryId": "my-id-2",
+    "entryType": "http://standardhealthrecord.org/spec/shr/test/ElementValue",
+    "CreationTime": { "Value": "2017-11-30T12:34:56Z", "entryType": "http://standardhealthrecord.org/spec/shr/core/CreationTime" },
     "Value": {
-      "ShrId": { "Value": "patient-id", "EntryType": { "Value": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/ShrId"} },
-      "EntryId": { "Value": "my-id", "EntryType": { "Value": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryId"} },
-      "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/test/Simple"},
-      "CreationTime": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"} },
+      "shrId": "patient-id",
+      "entryId": "my-id",
+      "entryType": "http://standardhealthrecord.org/spec/shr/test/Simple",
+      "CreationTime": { "Value": "2017-11-30T12:34:56Z", "entryType": "http://standardhealthrecord.org/spec/shr/core/CreationTime" },
       "Value": "I'm nested pretty deep."
     }
   }

--- a/test/fixtures/instances/TwoDeepElementValue.json
+++ b/test/fixtures/instances/TwoDeepElementValue.json
@@ -1,21 +1,18 @@
 {
-  "ShrId": { "Value": "patient-id", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId"} },
-  "EntryId": { "Value": "my-id-3", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId"} },
+  "ShrId": { "Value": "patient-id", "EntryType": { "Value": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/ShrId"} },
+  "EntryId": { "Value": "my-id-3", "EntryType": { "Value": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryId"} },
   "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/test/TwoDeepElementValue"},
   "CreationTime": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"} },
-  "LastUpdated": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"} },
   "Value": {
-    "ShrId": { "Value": "patient-id", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId"} },
-    "EntryId": { "Value": "my-id-2", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId"}  },
+    "ShrId": { "Value": "patient-id", "EntryType": { "Value": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/ShrId"} },
+    "EntryId": { "Value": "my-id-2", "EntryType": { "Value": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryId"}  },
     "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/test/ElementValue"},
     "CreationTime": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"} },
-    "LastUpdated": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"} },
     "Value": {
-      "ShrId": { "Value": "patient-id", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId"} },
-      "EntryId": { "Value": "my-id", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId"} },
+      "ShrId": { "Value": "patient-id", "EntryType": { "Value": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/ShrId"} },
+      "EntryId": { "Value": "my-id", "EntryType": { "Value": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryId"} },
       "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/test/Simple"},
       "CreationTime": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"} },
-      "LastUpdated": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"} },
       "Value": "I'm nested pretty deep."
     }
   }

--- a/test/fixtures/instances/TypeConstrainedReference.json
+++ b/test/fixtures/instances/TypeConstrainedReference.json
@@ -1,8 +1,8 @@
 {
-  "ShrId": { "Value": "patient-id", "EntryType": { "Value": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/ShrId"} },
-  "EntryId": { "Value": "my-id", "EntryType": { "Value": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryId"} },
-  "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/test/TypeConstrainedReference"},
-  "CreationTime": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"} },
+  "shrId": "patient-id",
+  "entryId": "my-id",
+  "entryType": "http://standardhealthrecord.org/spec/shr/test/TypeConstrainedReference",
+  "CreationTime": { "Value": "2017-11-30T12:34:56Z", "entryType": "http://standardhealthrecord.org/spec/shr/core/CreationTime" },
   "Value": {
     "_ShrId": "patient-id",
     "_EntryId": "another-id-2",

--- a/test/fixtures/instances/TypeConstrainedReference.json
+++ b/test/fixtures/instances/TypeConstrainedReference.json
@@ -1,9 +1,8 @@
 {
-  "ShrId": { "Value": "patient-id", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId"} },
-  "EntryId": { "Value": "my-id", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId"} },
+  "ShrId": { "Value": "patient-id", "EntryType": { "Value": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/ShrId"} },
+  "EntryId": { "Value": "my-id", "EntryType": { "Value": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryId"} },
   "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/test/TypeConstrainedReference"},
   "CreationTime": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"} },
-  "LastUpdated": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"} },
   "Value": {
     "_ShrId": "patient-id",
     "_EntryId": "another-id-2",

--- a/test/fixtures/instances/TypeConstraints.json
+++ b/test/fixtures/instances/TypeConstraints.json
@@ -1,39 +1,39 @@
 {
-  "ShrId": { "Value": "patient-id", "EntryType": { "Value": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/ShrId"} },
-  "EntryId": { "Value": "my-id", "EntryType": { "Value": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryId"} },
-  "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/test/GroupDerivative"},
-  "CreationTime": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"} },
+  "shrId": "patient-id",
+  "entryId": "my-id",
+  "entryType": "http://standardhealthrecord.org/spec/shr/test/GroupDerivative",
+  "CreationTime": { "Value": "2017-11-30T12:34:56Z", "entryType": "http://standardhealthrecord.org/spec/shr/core/CreationTime" },
   "Simple": {
-    "ShrId": { "Value": "patient-id", "EntryType": { "Value": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/ShrId"} },
-    "EntryId": { "Value": "my-id-2", "EntryType": { "Value": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryId"} },
-    "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/test/SimpleChild"},
-    "CreationTime": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"} },
+    "shrId": "patient-id",
+    "entryId": "my-id-2",
+    "entryType": "http://standardhealthrecord.org/spec/shr/test/SimpleChild",
+    "CreationTime": { "Value": "2017-11-30T12:34:56Z", "entryType": "http://standardhealthrecord.org/spec/shr/core/CreationTime" },
     "Value": "I'm nested pretty deep."
   },
   "ElementValue": [
     {
-      "ShrId": { "Value": "patient-id", "EntryType": { "Value": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/ShrId"} },
-      "EntryId": { "Value": "my-id-3", "EntryType": { "Value": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryId"} },
-      "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/test/ElementValue"},
-      "CreationTime": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"} },
+      "shrId": "patient-id",
+      "entryId": "my-id-3",
+      "entryType": "http://standardhealthrecord.org/spec/shr/test/ElementValue",
+      "CreationTime": { "Value": "2017-11-30T12:34:56Z", "entryType": "http://standardhealthrecord.org/spec/shr/core/CreationTime" },
       "Value": {
-        "ShrId": { "Value": "patient-id", "EntryType": { "Value": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/ShrId"} },
-        "EntryId": { "Value": "my-id-4", "EntryType": { "Value": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryId"} },
-        "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/test/SimpleChild"},
-        "CreationTime": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"} },
+        "shrId": "patient-id",
+        "entryId": "my-id-4",
+        "entryType": "http://standardhealthrecord.org/spec/shr/test/SimpleChild",
+        "CreationTime": { "Value": "2017-11-30T12:34:56Z", "entryType": "http://standardhealthrecord.org/spec/shr/core/CreationTime" },
         "Value": "I'm the first child."
       }
     },
     {
-      "ShrId": { "Value": "patient-id", "EntryType": { "Value": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/ShrId"} },
-      "EntryId": { "Value": "my-id-5", "EntryType": { "Value": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryId"} },
-      "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/test/ElementValue"},
-      "CreationTime": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"} },
+      "shrId": "patient-id",
+      "entryId": "my-id-5",
+      "entryType": "http://standardhealthrecord.org/spec/shr/test/ElementValue",
+      "CreationTime": { "Value": "2017-11-30T12:34:56Z", "entryType": "http://standardhealthrecord.org/spec/shr/core/CreationTime" },
       "Value": {
-        "ShrId": { "Value": "patient-id", "EntryType": { "Value": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/ShrId"} },
-        "EntryId": { "Value": "my-id-6", "EntryType": { "Value": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryId"} },
-        "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/test/SimpleChild"},
-        "CreationTime": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"} },
+        "shrId": "patient-id",
+        "entryId": "my-id-6",
+        "entryType": "http://standardhealthrecord.org/spec/shr/test/SimpleChild",
+        "CreationTime": { "Value": "2017-11-30T12:34:56Z", "entryType": "http://standardhealthrecord.org/spec/shr/core/CreationTime" },
         "Value": "I'm the second child."
       }
     }

--- a/test/fixtures/instances/TypeConstraints.json
+++ b/test/fixtures/instances/TypeConstraints.json
@@ -1,45 +1,39 @@
 {
-  "ShrId": { "Value": "patient-id", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId"} },
-  "EntryId": { "Value": "my-id", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId"} },
+  "ShrId": { "Value": "patient-id", "EntryType": { "Value": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/ShrId"} },
+  "EntryId": { "Value": "my-id", "EntryType": { "Value": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryId"} },
   "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/test/GroupDerivative"},
   "CreationTime": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"} },
-  "LastUpdated": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"} },
   "Simple": {
-    "ShrId": { "Value": "patient-id", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId"} },
-    "EntryId": { "Value": "my-id-2", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId"} },
+    "ShrId": { "Value": "patient-id", "EntryType": { "Value": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/ShrId"} },
+    "EntryId": { "Value": "my-id-2", "EntryType": { "Value": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryId"} },
     "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/test/SimpleChild"},
     "CreationTime": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"} },
-    "LastUpdated": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"} },
     "Value": "I'm nested pretty deep."
   },
   "ElementValue": [
     {
-      "ShrId": { "Value": "patient-id", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId"} },
-      "EntryId": { "Value": "my-id-3", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId"} },
+      "ShrId": { "Value": "patient-id", "EntryType": { "Value": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/ShrId"} },
+      "EntryId": { "Value": "my-id-3", "EntryType": { "Value": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryId"} },
       "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/test/ElementValue"},
       "CreationTime": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"} },
-      "LastUpdated": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"} },
       "Value": {
-        "ShrId": { "Value": "patient-id", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId"} },
-        "EntryId": { "Value": "my-id-4", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId"} },
+        "ShrId": { "Value": "patient-id", "EntryType": { "Value": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/ShrId"} },
+        "EntryId": { "Value": "my-id-4", "EntryType": { "Value": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryId"} },
         "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/test/SimpleChild"},
         "CreationTime": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"} },
-        "LastUpdated": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"} },
         "Value": "I'm the first child."
       }
     },
     {
-      "ShrId": { "Value": "patient-id", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId"} },
-      "EntryId": { "Value": "my-id-5", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId"} },
+      "ShrId": { "Value": "patient-id", "EntryType": { "Value": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/ShrId"} },
+      "EntryId": { "Value": "my-id-5", "EntryType": { "Value": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryId"} },
       "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/test/ElementValue"},
       "CreationTime": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"} },
-      "LastUpdated": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"} },
       "Value": {
-        "ShrId": { "Value": "patient-id", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/ShrId"} },
-        "EntryId": { "Value": "my-id-6", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/EntryId"} },
+        "ShrId": { "Value": "patient-id", "EntryType": { "Value": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/ShrId"} },
+        "EntryId": { "Value": "my-id-6", "EntryType": { "Value": "https://standardhealthrecord.org/schema/cimpl/builtin#/definitions/EntryId"} },
         "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/test/SimpleChild"},
         "CreationTime": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/core/CreationTime"} },
-        "LastUpdated": { "Value": "2017-11-30T12:34:56Z", "EntryType": { "Value": "http://standardhealthrecord.org/spec/shr/base/LastUpdated"} },
         "Value": "I'm the second child."
       }
     }


### PR DESCRIPTION
We are no longer supporting Entry, EntryId, EntryType, and ShrId in shr.base.  Now they're just built into our serialization implementation via the builtin schema.

This is PR 5 of 7 in the overall effort to remove the need for the shr.base.Entry element.

1. shr-models (standardhealth/shr-models#49)
2. shr-text-import (standardhealth/shr-text-import#110)
3. shr-expand (standardhealth/shr-expand#49)
4. shr-json-javadoc (standardhealth/shr-json-javadoc#28)
5. shr-json-schema-export
6. shr-fhir-export (standardhealth/shr-fhir-export#165)
7. shr-es6-export (standardhealth/shr-es6-export#60)